### PR TITLE
Get apikey api

### DIFF
--- a/.narval.yml
+++ b/.narval.yml
@@ -99,6 +99,15 @@ suites:
         specs:
           - test/functional/specs/users-api.specs.js
       coverage: *base-coverage
+    - name: security-tokens
+      describe: Security tokens api should work as expected
+      before: *base-before
+      services: *base-services
+      test: 
+        <<: *base-test
+        specs:
+          - test/functional/specs/security-tokens-api.specs.js
+      coverage: *base-coverage
     - name: authentication
       describe: JWT and apiKeys apis should work as expected
       before: *base-before

--- a/lib/Api.js
+++ b/lib/Api.js
@@ -1,13 +1,16 @@
 'use strict'
 
 const users = require('./api/users')
+const securityTokens = require('./api/securityTokens')
 
 const Api = (service, commands) => ({
-  openapis: [].concat(
-    users.openapi()
-  ),
+  openapis: [
+    ...users.openapi(),
+    ...securityTokens.openapi()
+  ],
   operations: {
-    ...users.Operations(service, commands)
+    ...users.Operations(service, commands),
+    ...securityTokens.Operations(service, commands)
   }
 })
 

--- a/lib/api/securityTokens.js
+++ b/lib/api/securityTokens.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const { omitBy, isUndefined } = require('lodash')
+
+const definition = require('./securityTokens.json')
+const { roles, API_KEY } = require('../security/utils')
+
+const Operations = (service, commands) => ({
+  getSecurityTokens: {
+    auth: (userData, params, body) => {
+      if (userData.role === roles.ADMIN || userData._id.toString() === params.query.user) {
+        return true
+      } else if (userData.role === roles.SERVICE_REGISTERER && params.query.type === API_KEY) {
+        return commands.user.get({
+          _id: params.query.user
+        }).then(user => {
+          if (user.role === roles.SERVICE) {
+            return Promise.resolve()
+          }
+          return Promise.reject(new service.errors.Forbidden())
+        })
+      } else {
+        return false
+      }
+    },
+    handler: (params, body, res) => {
+      const filter = omitBy({
+        type: params.query.type,
+        _user: params.query.user
+      }, isUndefined)
+      return commands.securityToken.getAll(filter)
+    }
+  }
+})
+
+const openapi = () => [definition]
+
+module.exports = {
+  Operations,
+  openapi
+}

--- a/lib/api/securityTokens.json
+++ b/lib/api/securityTokens.json
@@ -1,0 +1,98 @@
+{
+  "components": {
+    "schemas": {
+      "SecurityToken": {
+        "description": "Security Token data",
+        "type": "object",
+        "properties": {
+          "_id": {
+            "description": "Unique id of the token",
+            "type": "string"
+          },
+          "_user": {
+            "description": "Unique id of the user owner of the token",
+            "type": "string"
+          },
+          "token": {
+            "description": "Token",
+            "type": "string"
+          },
+          "type": {
+            "description": "Token type",
+            "type": "string",
+            "enum": ["apikey", "jwt"]
+          },
+          "createdAt": {
+            "description": "Creation date timestamp",
+            "type": "string"
+          },
+          "updatedAt": {
+            "description": "Last update date timestamp",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "example": {
+          "_id": "1223123",
+          "_user": "fdaq3r341212fsf",
+          "token": "1312dewrer4234rkr23424kffdsf",
+          "type": "jwt",
+          "createdAt": "2018-07-28T17:13:08.718Z",
+          "updatedAt": "2018-07-28T17:13:09.730Z"
+        }
+      },
+      "SecurityTokens": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SecurityToken"
+        }
+      }
+    }
+  },
+  "paths": {
+    "/auth/tokens": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "type": "string",
+              "enum": ["apikey", "jwt"]
+            },
+            "description": "Type of token"
+          },
+          {
+            "in": "query",
+            "name": "user",
+            "schema": {
+              "type": "string"
+            },
+            "description": "User id owner of the token"
+          }
+        ],
+        "tags": ["security"],
+        "summary": "Get security tokens",
+        "description": "Get registered Jwt refresh tokens and api keys",
+        "operationId": "getSecurityTokens",
+        "responses": {
+          "200": {
+            "description": "Get security tokens success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecurityTokens"
+                }
+              }
+            }
+          }
+        },
+        "security": [{
+          "jwt": []
+        }, {
+          "apiKey": []
+        }]
+      }
+    }
+  }
+}

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -22,14 +22,13 @@ const Operations = (service, commands) => ({
   },
   getUser: {
     auth: (userData, params, body) => {
-      // TODO, allow only to get services users if role = service_registerer
-      if (userData.role === roles.ADMIN || userData.role === roles.SERVICE_REGISTERER) {
+      if (userData.role === roles.ADMIN) {
         return true
       }
       return commands.user.get({
         name: params.path.name
       }).then(user => {
-        if (user._id.toString() === userData._id) {
+        if (user._id.toString() === userData._id || (userData.role === roles.SERVICE_REGISTERER && user.role === roles.SERVICE)) {
           return Promise.resolve()
         }
         return Promise.reject(new service.errors.Forbidden())

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -21,10 +21,20 @@ const Operations = (service, commands) => ({
       })
   },
   getUser: {
-    auth: userData => (
+    auth: (userData, params, body) => {
       // TODO, allow only to get services users if role = service_registerer
-      userData.role === roles.ADMIN || userData.role === roles.SERVICE_REGISTERER
-    ),
+      if (userData.role === roles.ADMIN || userData.role === roles.SERVICE_REGISTERER) {
+        return true
+      }
+      return commands.user.get({
+        name: params.path.name
+      }).then(user => {
+        if (user._id.toString() === userData._id) {
+          return Promise.resolve()
+        }
+        return Promise.reject(new service.errors.Forbidden())
+      })
+    },
     handler: (params, body, res) => commands.user.get({
       name: params.path.name
     })

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -22,6 +22,7 @@ const Operations = (service, commands) => ({
   },
   getUser: {
     auth: userData => (
+      // TODO, allow only to get services users if role = service_registerer
       userData.role === roles.ADMIN || userData.role === roles.SERVICE_REGISTERER
     ),
     handler: (params, body, res) => commands.user.get({

--- a/lib/commands/securityToken.js
+++ b/lib/commands/securityToken.js
@@ -5,6 +5,8 @@ const randToken = require('rand-token')
 const templates = require('../templates')
 const utils = require('../utils')
 
+const PUBLIC_FIELDS = '_user token type updatedAt createdAt'
+
 const Commands = (service, models, client) => {
   const ensureToken = token => {
     if (!token) {
@@ -25,7 +27,9 @@ const Commands = (service, models, client) => {
       .then(() => Promise.resolve(token))
   }
 
-  const get = (filter = {}) => models.SecurityToken.findOne(filter).then(ensureToken)
+  const getAll = (filter = {}) => models.SecurityToken.find(filter, PUBLIC_FIELDS)
+
+  const get = (filter = {}) => models.SecurityToken.findOne(filter, PUBLIC_FIELDS).then(ensureToken)
 
   const getUser = token => get({token})
     .then(tokenData => models.User.findById(tokenData._user))
@@ -40,6 +44,7 @@ const Commands = (service, models, client) => {
     add,
     remove,
     get,
+    getAll,
     getUser
   }
 }

--- a/test/functional/specs/security-tokens-api.specs.js
+++ b/test/functional/specs/security-tokens-api.specs.js
@@ -1,0 +1,218 @@
+
+const test = require('narval')
+
+const utils = require('./utils')
+
+test.describe('security tokens api', function () {
+  let authenticator = utils.Authenticator()
+
+  const operatorUser = {
+    name: 'foo-operator',
+    role: 'operator',
+    email: 'operator@foo.com',
+    password: 'foo'
+  }
+
+  const serviceUser = {
+    name: 'foo-service-user',
+    role: 'service',
+    email: 'service@foo.com',
+    password: 'foo'
+  }
+
+  const pluginUser = {
+    name: 'foo-plugin',
+    role: 'plugin',
+    email: 'plugin@foo.com',
+    password: 'foo'
+  }
+
+  const serviceRegistererUser = {
+    name: 'foo-service-registerer',
+    role: 'service-registerer',
+    email: 'service-registerer@foo.com',
+    password: 'foo'
+  }
+
+  const getAuthTokens = filters => {
+    return utils.request('/auth/tokens', {
+      method: 'GET',
+      query: filters,
+      ...authenticator.credentials()
+    })
+  }
+
+  const getUser = function (userName) {
+    return utils.request(`/users/${userName}`, {
+      method: 'GET',
+      ...authenticator.credentials()
+    })
+  }
+
+  test.describe('get auth tokens api resource', () => {
+    test.describe('when no authenticated', () => {
+      test.it('should return an authentication error', () => {
+        return getAuthTokens().then(response => {
+          return Promise.all([
+            test.expect(response.body.message).to.contain('Authentication required'),
+            test.expect(response.statusCode).to.equal(401)
+          ])
+        })
+      })
+    })
+
+    test.describe('when user is admin', () => {
+      test.before(() => {
+        return utils.doLogin(authenticator)
+      })
+
+      test.it('should return all existant security tokens if no filter is received', () => {
+        return getAuthTokens().then(response => {
+          return test.expect(response.body.length).to.equal(2)
+        })
+      })
+
+      test.it('should return all existant security tokens aplying received type filter', () => {
+        const type = 'apikey'
+        return getAuthTokens({
+          type
+        }).then(response => {
+          return Promise.all([
+            test.expect(response.body[0].type).to.equal(type),
+            test.expect(response.body.length).to.equal(1)
+          ])
+        })
+      })
+
+      test.it('should return all existant security tokens aplying received user filter', () => {
+        return getUser('admin')
+          .then(userData => {
+            return getAuthTokens({
+              user: userData.body._id
+            }).then(response => {
+              return Promise.all([
+                test.expect(response.body[0]._user).to.equal(userData.body._id),
+                test.expect(response.body.length).to.equal(1)
+              ])
+            })
+          })
+      })
+    })
+
+    const testRole = function (user) {
+      test.describe(`when user has role "${user.role}"`, () => {
+        let adminUserId
+
+        test.before(() => {
+          return utils.doLogin(authenticator)
+            .then(() => {
+              return getUser('admin')
+                .then((response) => {
+                  adminUserId = response.body._id
+                  return utils.ensureUserAndDoLogin(authenticator, user)
+                })
+            })
+        })
+
+        test.it('should return a forbidden error if no user query is received', () => {
+          return getAuthTokens().then((response) => {
+            return Promise.all([
+              test.expect(response.body.message).to.contain('Not authorized'),
+              test.expect(response.statusCode).to.equal(403)
+            ])
+          })
+        })
+
+        test.it('should return tokens if user in query is same than user id', () => {
+          return getUser(user.name)
+            .then(userData => {
+              return getAuthTokens({
+                user: userData.body._id
+              }).then(response => {
+                return Promise.all([
+                  test.expect(response.body[0]._user).to.equal(userData.body._id),
+                  test.expect(response.body.length).to.equal(1)
+                ])
+              })
+            })
+        })
+
+        test.it('should return a forbidden error if user in query is different than user id', () => {
+          return getAuthTokens({
+            user: adminUserId
+          }).then((response) => {
+            return Promise.all([
+              test.expect(response.body.message).to.contain('Not authorized'),
+              test.expect(response.statusCode).to.equal(403)
+            ])
+          })
+        })
+      })
+    }
+
+    testRole(operatorUser)
+    testRole(serviceUser)
+    testRole(pluginUser)
+    testRole(serviceRegistererUser)
+
+    test.describe('When user has service-registerer role and request tokens of an user different to himself', () => {
+      test.before(() => {
+        return utils.ensureUserAndDoLogin(authenticator, serviceRegistererUser)
+      })
+
+      test.it('should return a forbidden error if requested user has not a "service" role', () => {
+        return utils.ensureUserAndDoLogin(authenticator, operatorUser)
+          .then(() => {
+            return getUser(operatorUser.name)
+              .then(response => {
+                const operatorId = response.body._id
+                return utils.ensureUserAndDoLogin(authenticator, serviceRegistererUser)
+                  .then(() => {
+                    return getAuthTokens({
+                      type: 'apikey',
+                      user: operatorId
+                    }).then((response) => {
+                      return Promise.all([
+                        test.expect(response.body.message).to.contain('Not authorized'),
+                        test.expect(response.statusCode).to.equal(403)
+                      ])
+                    })
+                  })
+              })
+          })
+      })
+
+      test.it('should return tokens data if requested user has "service" role and requested type is "apikey"', () => {
+        return getUser(serviceUser.name)
+          .then(response => {
+            const serviceId = response.body._id
+            return getAuthTokens({
+              type: 'apikey',
+              user: serviceId
+            }).then((response) => {
+              return Promise.all([
+                test.expect(response.statusCode).to.equal(200),
+                test.expect(response.body).to.be.an('array')
+              ])
+            })
+          })
+      })
+
+      test.it('should return a forbidden error if requested type if different to "apikey"', () => {
+        return getUser(serviceUser.name)
+          .then(response => {
+            const serviceId = response.body._id
+            return getAuthTokens({
+              type: 'jwt',
+              user: serviceId
+            }).then((response) => {
+              return Promise.all([
+                test.expect(response.body.message).to.contain('Not authorized'),
+                test.expect(response.statusCode).to.equal(403)
+              ])
+            })
+          })
+      })
+    })
+  })
+})

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -291,11 +291,22 @@ test.describe('users api', function () {
       })
 
       test.describe('get user', () => {
-        test.it('should return a forbidden error', () => {
+        test.it('should return a forbidden error if user is different to himself', () => {
           return getUser(newUser.name).then(response => {
             return Promise.all([
               test.expect(response.body.message).to.contain('Not authorized'),
               test.expect(response.statusCode).to.equal(403)
+            ])
+          })
+        })
+
+        test.it('should return user data if user is himself', () => {
+          return getUser(user.name).then(response => {
+            return Promise.all([
+              test.expect(response.body.name).to.equal(user.name),
+              test.expect(response.body.email).to.equal(user.email),
+              test.expect(response.body.role).to.equal(user.role),
+              test.expect(response.statusCode).to.equal(200)
             ])
           })
         })

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -22,7 +22,7 @@ test.describe('users api', function () {
 
   const newUser = {
     name: 'foo-service',
-    role: 'service',
+    role: 'operator',
     email: 'foo2@foo.com',
     password: 'foo'
   }
@@ -317,6 +317,7 @@ test.describe('users api', function () {
   testRole(operatorUser)
   testRole(serviceUser)
   testRole(pluginUser)
+  testRole(serviceRegistererUser)
 
   test.describe(`when user has role "service-registerer"`, () => {
     test.before(() => {
@@ -360,29 +361,28 @@ test.describe('users api', function () {
     })
 
     test.describe('get user', () => {
-      test.it('should return user data', () => {
-        return getUser(newUser.name)
+      test.it('should return user data if user has "service" role', () => {
+        return getUser(serviceUser.name)
           .then((response) => {
             const user = response.body
             return Promise.all([
               test.expect(user._id).to.not.be.undefined(),
-              test.expect(user.name).to.equal(newUser.name),
-              test.expect(user.role).to.equal(newUser.role),
-              test.expect(user.email).to.equal(newUser.email),
+              test.expect(user.name).to.equal(serviceUser.name),
+              test.expect(user.role).to.equal(serviceUser.role),
+              test.expect(user.email).to.equal(serviceUser.email),
               test.expect(user.createdAt).to.not.be.undefined(),
               test.expect(user.updatedAt).to.not.be.undefined()
             ])
           })
       })
 
-      test.it('should return a not found response when user does not exist', () => {
-        return getUser('foo-unexistant-user')
-          .then((response) => {
-            return Promise.all([
-              test.expect(response.body.message).to.equal('User not found'),
-              test.expect(response.statusCode).to.equal(404)
-            ])
-          })
+      test.it('should return a forbidden error if user has a role different to "service"', () => {
+        return getUser(newUser.name).then(response => {
+          return Promise.all([
+            test.expect(response.body.message).to.contain('Not authorized'),
+            test.expect(response.statusCode).to.equal(403)
+          ])
+        })
       })
     })
   })

--- a/test/functional/specs/utils.js
+++ b/test/functional/specs/utils.js
@@ -2,7 +2,9 @@
 
 const path = require('path')
 const fs = require('fs')
+const querystring = require('querystring')
 
+const { omitBy, isUndefined } = require('lodash')
 const requestPromise = require('request-promise')
 
 const SERVICE_HOST = process.env.controller_host_name
@@ -38,8 +40,12 @@ const waitOnestimatedStartTime = function (time = ESTIMATED_START_TIME) {
 }
 
 const request = function (uri, options = {}) {
+  let url = `http://${SERVICE_HOST}:${SERVICE_PORT}/api${uri}`
+  if (options.query) {
+    url = `${url}?${querystring.stringify(omitBy(options.query, isUndefined))}`
+  }
   const defaultOptions = {
-    uri: `http://${SERVICE_HOST}:${SERVICE_PORT}/api${uri}`,
+    uri: url,
     json: true,
     strictSSL: false,
     rejectUnauthorized: false,

--- a/test/unit/Base.mocks.js
+++ b/test/unit/Base.mocks.js
@@ -24,7 +24,8 @@ const Mock = function () {
     errors: {
       BadData: sandbox.stub().returns(new Error()),
       NotFound: sandbox.stub().returns(new Error()),
-      MethodNotAllowed: sandbox.stub().returns(new Error())
+      MethodNotAllowed: sandbox.stub().returns(new Error()),
+      Forbidden: sandbox.stub().returns(new Error())
     }
   }
 

--- a/test/unit/lib/Api.specs.js
+++ b/test/unit/lib/Api.specs.js
@@ -9,17 +9,20 @@ const Api = require('../../../lib/Api')
 test.describe('Api', () => {
   let baseMocks
   let usersMocks
+  let securityTokensMocks
   let api
 
   test.beforeEach(() => {
     baseMocks = new mocks.Base()
     usersMocks = new mocks.api.Users()
+    securityTokensMocks = new mocks.api.SecurityTokens()
     api = Api(baseMocks.stubs.service)
   })
 
   test.afterEach(() => {
     baseMocks.restore()
     usersMocks.restore()
+    securityTokensMocks.restore()
   })
 
   test.describe('instance', () => {
@@ -33,7 +36,9 @@ test.describe('Api', () => {
       test.it('should contain all api operations', () => {
         return test.expect(api.operations).to.have.all.keys(
           'getUsers',
-          'addUser'
+          'addUser',
+          'getUser',
+          'getSecurityTokens'
         )
       })
     })

--- a/test/unit/lib/Commands.specs.js
+++ b/test/unit/lib/Commands.specs.js
@@ -40,6 +40,7 @@ test.describe('Commands', () => {
       return test.expect(commands.securityToken).to.have.all.keys(
         'add',
         'getUser',
+        'getAll',
         'remove',
         'get'
       )

--- a/test/unit/lib/api/SecurityTokens.mocks.js
+++ b/test/unit/lib/api/SecurityTokens.mocks.js
@@ -1,27 +1,21 @@
 
 const test = require('narval')
 
-const users = require('../../../../lib/api/users')
+const securityTokens = require('../../../../lib/api/securityTokens')
 
 const Mock = function () {
   const sandbox = test.sinon.createSandbox()
 
   const operationsStubs = {
-    getUsers: {
-      handler: sandbox.stub().usingPromise().resolves()
-    },
-    addUser: {
-      handler: sandbox.stub().usingPromise().resolves()
-    },
-    getUser: {
+    getSecurityTokens: {
       handler: sandbox.stub().usingPromise().resolves()
     }
   }
 
   const stubs = {
     operations: operationsStubs,
-    Operations: sandbox.stub(users, 'Operations').returns(operationsStubs),
-    openapi: sandbox.stub(users, 'openapi').returns([])
+    Operations: sandbox.stub(securityTokens, 'Operations').returns(operationsStubs),
+    openapi: sandbox.stub(securityTokens, 'openapi').returns([])
   }
 
   const restore = function () {

--- a/test/unit/lib/api/securityTokens.specs.js
+++ b/test/unit/lib/api/securityTokens.specs.js
@@ -1,0 +1,140 @@
+
+const test = require('narval')
+
+const mocks = require('../../mocks')
+
+const securityTokens = require('../../../../lib/api/securityTokens')
+const definition = require('../../../../lib/api/securityTokens.json')
+
+test.describe('securityTokens users', () => {
+  test.describe('Operations instance', () => {
+    let operations
+    let commandsMocks
+    let baseMocks
+
+    test.beforeEach(() => {
+      baseMocks = new mocks.Base()
+      commandsMocks = new mocks.Commands()
+      operations = securityTokens.Operations(baseMocks.stubs.service, commandsMocks.stubs)
+    })
+
+    test.afterEach(() => {
+      baseMocks.restore()
+      commandsMocks.restore()
+    })
+
+    test.describe('getSecurityTokens auth', () => {
+      test.it('should return true if provided user has "admin" role', () => {
+        test.expect(operations.getSecurityTokens.auth({
+          role: 'admin',
+          _id: ''
+        }, {
+          query: {}
+        }, {})).to.be.true()
+      })
+
+      const testRole = function (role) {
+        test.it(`should return false if provided user has "${role}" role and no query is received`, () => {
+          test.expect(operations.getSecurityTokens.auth({
+            role,
+            _id: ''
+          }, {
+            query: {
+            }
+          }, {})).to.be.false()
+        })
+      }
+
+      testRole('service')
+      testRole('operator')
+      testRole('plugin')
+      testRole('service-registerer')
+
+      test.it('should return true if provided user has same id than received user in query', () => {
+        const fooId = 'foo-id'
+        test.expect(operations.getSecurityTokens.auth({
+          _id: fooId
+        }, {
+          query: {
+            user: fooId
+          }
+        }, {})).to.be.true()
+      })
+
+      test.describe('when user has service-registerer role, and query type is apikey', () => {
+        test.it('should resolve the promise if received user in query has "service" role', () => {
+          commandsMocks.stubs.user.get.resolves({
+            role: 'service'
+          })
+          return operations.getSecurityTokens.auth({ role: 'service-registerer', _id: '' }, { query: {
+            type: 'apikey',
+            user: 'foo-id'
+          }}, {}).then(result => {
+            return test.expect(true).to.be.true()
+          })
+        })
+
+        test.it('should reject the promise if received user in query has a role different to "service"', () => {
+          const forbiddenError = new Error('forbidden')
+          commandsMocks.stubs.user.get.resolves({
+            role: 'admin'
+          })
+          baseMocks.stubs.service.errors.Forbidden.returns(forbiddenError)
+          return operations.getSecurityTokens.auth({ role: 'service-registerer', _id: '' }, { query: {
+            type: 'apikey',
+            user: 'foo-id'
+          }}, {}).then(result => {
+            return test.assert.fail()
+          }, (error) => {
+            return test.expect(error).to.equal(forbiddenError)
+          })
+        })
+      })
+    })
+
+    test.describe('getSecurityTokens handler', () => {
+      test.it('should return all security tokens if no query is received', () => {
+        const fooResult = 'foo result'
+        commandsMocks.stubs.securityToken.getAll.resolves(fooResult)
+
+        return operations.getSecurityTokens.handler({
+          query: {}
+        })
+          .then((result) => {
+            return Promise.all([
+              test.expect(result).to.equal(fooResult),
+              test.expect(commandsMocks.stubs.securityToken.getAll).to.have.been.calledWith({})
+            ])
+          })
+      })
+
+      test.it('should pass type query as a filter if it is received', () => {
+        const fooType = 'foo type'
+        return operations.getSecurityTokens.handler({
+          query: {
+            type: fooType
+          }
+        }).then(() => test.expect(commandsMocks.stubs.securityToken.getAll).to.have.been.calledWith({
+          type: fooType
+        }))
+      })
+
+      test.it('should pass user query as a filter if it is received', () => {
+        const fooUser = 'foo type'
+        return operations.getSecurityTokens.handler({
+          query: {
+            user: fooUser
+          }
+        }).then(() => test.expect(commandsMocks.stubs.securityToken.getAll).to.have.been.calledWith({
+          _user: fooUser
+        }))
+      })
+    })
+  })
+
+  test.describe('openapi', () => {
+    test.it('should return an array containing the openapi definition', () => {
+      test.expect(securityTokens.openapi()).to.deep.equal([definition])
+    })
+  })
+})

--- a/test/unit/lib/api/users.specs.js
+++ b/test/unit/lib/api/users.specs.js
@@ -73,10 +73,39 @@ test.describe('api users', () => {
       })
 
       const testRole = function (role) {
-        test.it(`should return false if provided user has "${role}" role`, () => {
-          test.expect(operations.getUser.auth({
+        test.it(`should reject the promise if provided user has "${role}" role and requested user is different to himself`, () => {
+          commandsMocks.stubs.user.get.resolves({
+            _id: 'foo-different-id'
+          })
+          return operations.getUser.auth({
+            _id: 'foo-id',
             role
-          }, {}, {})).to.be.false()
+          }, {
+            path: {
+              name: 'foo-name'
+            }
+          }, {}).then(() => {
+            return test.assert.fail()
+          }, (error) => {
+            return test.expect(error).to.be.an.instanceof(Error)
+          })
+        })
+
+        test.it(`should resolve the promise if provided user has "${role}" role and requested user is same to himself`, () => {
+          const fooId = 'foo-id'
+          commandsMocks.stubs.user.get.resolves({
+            _id: fooId
+          })
+          return operations.getUser.auth({
+            _id: fooId,
+            role
+          }, {
+            path: {
+              name: 'foo-name'
+            }
+          }, {}).then(() => {
+            return test.expect(true).to.be.true()
+          })
         })
       }
       testRole('service')

--- a/test/unit/lib/api/users.specs.js
+++ b/test/unit/lib/api/users.specs.js
@@ -66,12 +66,6 @@ test.describe('api users', () => {
         }, {}, {})).to.be.true()
       })
 
-      test.it('should return true if provided user has "service-registerer" role', () => {
-        test.expect(operations.getUser.auth({
-          role: 'service-registerer'
-        }, {}, {})).to.be.true()
-      })
-
       const testRole = function (role) {
         test.it(`should reject the promise if provided user has "${role}" role and requested user is different to himself`, () => {
           commandsMocks.stubs.user.get.resolves({
@@ -111,6 +105,43 @@ test.describe('api users', () => {
       testRole('service')
       testRole('operator')
       testRole('plugin')
+      testRole('service-registerer')
+
+      test.describe('when logged user has service-registerer role', () => {
+        test.it('should resolve the promise if provided user has "service" role', () => {
+          commandsMocks.stubs.user.get.resolves({
+            _id: 'foo-id',
+            role: 'service'
+          })
+          return operations.getUser.auth({
+            role: 'service-registerer'
+          }, {
+            path: {
+              name: 'foo-name'
+            }
+          }, {}).then(() => {
+            return test.expect(true).to.be.true()
+          })
+        })
+
+        test.it('should reject the promise if provided user has a role different to "service"', () => {
+          commandsMocks.stubs.user.get.resolves({
+            _id: 'foo-id',
+            role: 'operator'
+          })
+          return operations.getUser.auth({
+            role: 'service-registerer'
+          }, {
+            path: {
+              name: 'foo-name'
+            }
+          }, {}).then(() => {
+            return test.assert.fail()
+          }, (error) => {
+            return test.expect(error).to.be.an.instanceof(Error)
+          })
+        })
+      })
     })
 
     test.describe('getUser handler', () => {

--- a/test/unit/lib/commands/SecurityToken.mocks.js
+++ b/test/unit/lib/commands/SecurityToken.mocks.js
@@ -9,6 +9,7 @@ const Mock = function () {
   const commandsStubs = {
     add: sandbox.stub().usingPromise().resolves(),
     getUser: sandbox.stub().usingPromise().resolves(),
+    getAll: sandbox.stub().usingPromise().resolves(),
     remove: sandbox.stub().usingPromise().resolves(),
     get: sandbox.stub().usingPromise().resolves()
   }

--- a/test/unit/lib/commands/securityToken.specs.js
+++ b/test/unit/lib/commands/securityToken.specs.js
@@ -81,7 +81,7 @@ test.describe('securityToken commands', () => {
     })
 
     test.describe('get method', () => {
-      test.it('should call to find security token and return the result', () => {
+      test.it('should call to find one security token and return the result', () => {
         const fooFilter = {
           _user: 'foo-id'
         }
@@ -105,6 +105,37 @@ test.describe('securityToken commands', () => {
             return Promise.all([
               test.expect(result).to.equal(fooToken),
               test.expect(modelsMocks.stubs.SecurityToken.findOne).to.have.been.calledWith({})
+            ])
+          })
+      })
+    })
+
+    test.describe('getAll method', () => {
+      const fooFilter = {
+        _user: 'foo-id'
+      }
+      const fooTokens = [{
+        token: 'foo'
+      }]
+
+      test.it('should call to find security tokens and return the result', () => {
+        modelsMocks.stubs.SecurityToken.find.resolves(fooTokens)
+        return commands.getAll(fooFilter)
+          .then((result) => {
+            return Promise.all([
+              test.expect(result).to.equal(fooTokens),
+              test.expect(modelsMocks.stubs.SecurityToken.find).to.have.been.calledWith(fooFilter)
+            ])
+          })
+      })
+
+      test.it('should call to find security tokens with an empty filter if it is not provided', () => {
+        modelsMocks.stubs.SecurityToken.find.resolves(fooTokens)
+        return commands.getAll()
+          .then((result) => {
+            return Promise.all([
+              test.expect(result).to.equal(fooTokens),
+              test.expect(modelsMocks.stubs.SecurityToken.find).to.have.been.calledWith({})
             ])
           })
       })

--- a/test/unit/lib/models/SecurityToken.mocks.js
+++ b/test/unit/lib/models/SecurityToken.mocks.js
@@ -12,6 +12,7 @@ const Mock = function () {
 
   const SecurityTokenStub = sandbox.stub().returns(securityTokenStub)
   SecurityTokenStub.findOne = sandbox.stub().usingPromise().resolves()
+  SecurityTokenStub.find = sandbox.stub().usingPromise().resolves()
   SecurityTokenStub.deleteOne = sandbox.stub().usingPromise().resolves()
 
   const stubs = {

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -10,6 +10,7 @@ const Index = require('./lib/Index.mocks')
 const Models = require('./lib/Models.mocks')
 const Security = require('./lib/Security.mocks')
 const UsersApi = require('./lib/api/Users.mocks')
+const SecurityTokensApi = require('./lib/api/SecurityTokens.mocks')
 const UserCommands = require('./lib/commands/User.mocks')
 const SecurityTokenCommands = require('./lib/commands/SecurityToken.mocks')
 const ComposedCommands = require('./lib/commands/Composed.mocks')
@@ -20,7 +21,8 @@ const Utils = require('./lib/Utils.mocks')
 module.exports = {
   Api,
   api: {
-    Users: UsersApi
+    Users: UsersApi,
+    SecurityTokens: SecurityTokensApi
   },
   commands: {
     User: UserCommands,


### PR DESCRIPTION
- Add GET /auth/tokens api
- Change GET /users/{name} api permissions. Allow service-registerer users to get only users with "service" role.
