### PR TITLE
Api permissions and params

### DIFF
--- a/lib/api/abilities.js
+++ b/lib/api/abilities.js
@@ -15,18 +15,18 @@ const Operations = (service, commands) => ({
     }
   },
   getAbility: {
-    handler: (params, body, res) => commands.ability.getById(params.path._id)
+    handler: (params, body, res) => commands.ability.getById(params.path.id)
   },
   updateAbility: {
     auth: (userData, params, body) => {
-      return commands.ability.getById(params.path._id).then(abilityData => {
+      return commands.ability.getById(params.path.id).then(abilityData => {
         if (abilityData._user === userData._id) {
           return Promise.resolve()
         }
         return Promise.reject(new service.errors.Forbidden())
       })
     },
-    handler: (params, body, res) => commands.ability.update(params.path._id, body).then(abilityData => {
+    handler: (params, body, res) => commands.ability.update(params.path.id, body).then(abilityData => {
       res.status(204)
       res.header('location', `/api/abilities/${abilityData._id}`)
       return Promise.resolve()

--- a/lib/api/abilities.json
+++ b/lib/api/abilities.json
@@ -272,7 +272,7 @@
           "description": "Rele control",
           "eventDescription": "Rele has changed state",
           "actionDescription": "Changes rele state",
-          "stateDescription": "Current rele state",
+          "stateDescription": "Current rele state"
         }
       },
       "Abilities": {

--- a/lib/api/abilities.json
+++ b/lib/api/abilities.json
@@ -356,17 +356,17 @@
         }]
       }
     },
-    "/abilities/{_id}": {
+    "/abilities/{id}": {
       "get": {
         "parameters": [
           {
             "in": "path",
-            "name": "_id",
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "required": true,
-            "description": "Ability _id"
+            "description": "Ability id"
           }
         ],
         "tags": ["ability"],
@@ -395,12 +395,12 @@
         "parameters": [
           {
             "in": "path",
-            "name": "_id",
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "required": true,
-            "description": "Ability _id"
+            "description": "Ability id"
           }
         ],
         "tags": ["ability"],

--- a/lib/api/abilities.json
+++ b/lib/api/abilities.json
@@ -34,13 +34,25 @@
             "description": "Ability is able to dispatch event",
             "type": "boolean"
           },
+          "eventDescription": {
+            "description": "Description of the ability event",
+            "type": "string"
+          },
           "action": {
             "description": "Ability is able to handle an action",
             "type": "boolean"
           },
+          "actionDescription": {
+            "description": "Description of the ability action",
+            "type": "string"
+          },
           "state": {
             "description": "Ability has an state",
             "type": "boolean"
+          },
+          "stateDescription": {
+            "description": "Description of the ability state",
+            "type": "string"
           },
           "type": {
             "description": "Type of ability data",
@@ -116,8 +128,11 @@
           "_user": "132defwer4321312",
           "description": "Rele control",
           "event": true,
+          "eventDescription": "Rele has changed state",
           "action": true,
+          "actionDescription": "Changes rele state",
           "state": true,
+          "stateDescription": "Current rele state",
           "type": "boolean",
           "createdAt": "2018-07-28T17:13:08.718Z",
           "updatedAt": "2018-07-28T17:13:09.730Z"
@@ -140,13 +155,25 @@
             "description": "Ability is able to dispatch event",
             "type": "boolean"
           },
+          "eventDescription": {
+            "description": "Description of the ability event",
+            "type": "string"
+          },
           "action": {
             "description": "Ability is able to handle an action",
             "type": "boolean"
           },
+          "actionDescription": {
+            "description": "Description of the ability action",
+            "type": "string"
+          },
           "state": {
             "description": "Ability has an state",
             "type": "boolean"
+          },
+          "stateDescription": {
+            "description": "Description of the ability state",
+            "type": "string"
           },
           "type": {
             "description": "Type of ability data",
@@ -211,8 +238,11 @@
           "name": "foo-ability-name",
           "description": "Rele control",
           "event": true,
+          "eventDescription": "Rele has changed state",
           "action": true,
+          "actionDescription": "Changes rele state",
           "state": true,
+          "stateDescription": "Current rele state",
           "type": "boolean"
         }
       },
@@ -223,11 +253,26 @@
           "description": {
             "description": "Description of the ability",
             "type": "string"
+          },
+          "eventDescription": {
+            "description": "Description of the ability event",
+            "type": "string"
+          },
+          "actionDescription": {
+            "description": "Description of the ability action",
+            "type": "string"
+          },
+          "stateDescription": {
+            "description": "Description of the ability state",
+            "type": "string"
           }
         },
         "additionalProperties": false,
         "example": {
-          "description": "Rele control"
+          "description": "Rele control",
+          "eventDescription": "Rele has changed state",
+          "actionDescription": "Changes rele state",
+          "stateDescription": "Current rele state",
         }
       },
       "Abilities": {

--- a/lib/api/securityTokens.json
+++ b/lib/api/securityTokens.json
@@ -20,7 +20,7 @@
           "type": {
             "description": "Token type",
             "type": "string",
-            "enum": ["apikey", "jwt"]
+            "enum": ["apiKey", "jwt"]
           },
           "createdAt": {
             "description": "Creation date timestamp",
@@ -58,7 +58,7 @@
             "name": "type",
             "schema": {
               "type": "string",
-              "enum": ["apikey", "jwt"]
+              "enum": ["apiKey", "jwt"]
             },
             "description": "Type of token"
           },

--- a/lib/api/services.js
+++ b/lib/api/services.js
@@ -8,16 +8,16 @@ const Operations = (service, commands) => ({
     handler: (params, body, res) => commands.service.getFiltered()
   },
   getService: {
-    handler: (params, body, res) => commands.service.getById(params.path._id)
+    handler: (params, body, res) => commands.service.getById(params.path.id)
   },
   updateService: {
-    auth: (userData, params, body) => commands.service.getById(params.path._id).then(serviceData => {
+    auth: (userData, params, body) => commands.service.getById(params.path.id).then(serviceData => {
       if (serviceData._user === userData._id) {
         return Promise.resolve()
       }
       return Promise.reject(new service.errors.Forbidden())
     }),
-    handler: (params, body, res) => commands.service.update(params.path._id, body).then(serviceData => {
+    handler: (params, body, res) => commands.service.update(params.path.id, body).then(serviceData => {
       res.status(204)
       res.header('location', `/api/services/${serviceData._id}`)
       return Promise.resolve()

--- a/lib/api/services.json
+++ b/lib/api/services.json
@@ -214,17 +214,17 @@
         }]
       }
     },
-    "/services/{_id}": {
+    "/services/{id}": {
       "get": {
         "parameters": [
           {
             "in": "path",
-            "name": "_id",
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "required": true,
-            "description": "Service _id"
+            "description": "Service id"
           }
         ],
         "tags": ["service"],
@@ -253,12 +253,12 @@
         "parameters": [
           {
             "in": "path",
-            "name": "_id",
+            "name": "id",
             "schema": {
               "type": "string"
             },
             "required": true,
-            "description": "Service _id"
+            "description": "Service id"
           }
         ],
         "tags": ["service"],

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -3,7 +3,7 @@
 const { omitBy, isUndefined } = require('lodash')
 
 const definition = require('./users.json')
-const { onlyAdmin, roles } = require('../security/utils')
+const { roles } = require('../security/utils')
 
 const Operations = (service, commands) => ({
   getUsers: {

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -7,10 +7,14 @@ const { roles } = require('../security/utils')
 
 const Operations = (service, commands) => ({
   getUsers: {
-    auth: (userData, params, body) => (userData.role === roles.ADMIN || userData.role === roles.SERVICE_REGISTERER),
+    auth: (userData, params, body) => (
+      userData.role === roles.ADMIN ||
+      (userData.role === roles.SERVICE_REGISTERER && params.query.role === roles.SERVICE)
+    ),
     handler: (params, body, res) => {
       const filter = omitBy({
-        name: params.query.name
+        name: params.query.name,
+        role: params.query.role
       }, isUndefined)
       return commands.user.getFiltered(filter)
     }
@@ -28,8 +32,8 @@ const Operations = (service, commands) => ({
       })
   },
   getUser: {
-    auth: (userData, params, body) => (userData.role === roles.ADMIN || params.path._id === userData._id),
-    handler: (params, body, res) => commands.user.getById(params.path._id)
+    auth: (userData, params, body) => (userData.role === roles.ADMIN || params.path.id === userData._id),
+    handler: (params, body, res) => commands.user.getById(params.path.id)
   },
   getUserMe: {
     handler: (params, body, res, userData) => commands.user.getById(userData._id)

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -1,12 +1,19 @@
 'use strict'
 
+const { omitBy, isUndefined } = require('lodash')
+
 const definition = require('./users.json')
 const { onlyAdmin, roles } = require('../security/utils')
 
 const Operations = (service, commands) => ({
   getUsers: {
-    auth: onlyAdmin,
-    handler: () => commands.user.getAll()
+    auth: (userData, params, body) => (userData.role === roles.ADMIN || userData.role === roles.SERVICE_REGISTERER),
+    handler: (params, body, res) => {
+      const filter = omitBy({
+        name: params.query.name
+      }, isUndefined)
+      return commands.user.getFiltered(filter)
+    }
   },
   addUser: {
     auth: (userData, params, body) => (

--- a/lib/api/users.json
+++ b/lib/api/users.json
@@ -101,6 +101,16 @@
   "paths": {
     "/users": {
       "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Service name"
+          }
+        ],
         "tags": ["user"],
         "summary": "Return users",
         "description": "Returns an array with all registered users",

--- a/lib/api/users.json
+++ b/lib/api/users.json
@@ -26,7 +26,7 @@
           "role": {
             "description": "Role assigned to the user",
             "type": "string",
-            "enum": ["admin", "service", "plugin"]
+            "enum": ["admin", "operator", "service", "plugin", "service-registerer"]
           },
           "createdAt": {
             "description": "Creation date timestamp",
@@ -68,7 +68,7 @@
           "role": {
             "description": "Role assigned to the user",
             "type": "string",
-            "enum": ["admin", "operator", "service", "service-registerer", "plugin"]
+            "enum": ["admin", "operator", "service", "plugin", "service-registerer"]
           }
         },
         "required": ["name", "role"],
@@ -107,6 +107,15 @@
             "name": "name",
             "schema": {
               "type": "string"
+            },
+            "description": "Service name"
+          },
+          {
+            "in": "query",
+            "name": "role",
+            "schema": {
+              "type": "string",
+              "enum": ["admin", "operator", "service", "plugin", "service-registerer"]
             },
             "description": "Service name"
           }
@@ -186,12 +195,12 @@
         }]
       }
     },
-    "/users/{_id}": {
+    "/users/{id}": {
       "get": {
         "parameters": [
           {
             "in": "path",
-            "name": "_id",
+            "name": "id",
             "schema": {
               "type": "string"
             },

--- a/lib/commands/user.js
+++ b/lib/commands/user.js
@@ -24,6 +24,8 @@ const Commands = (service, models, client) => {
 
   const getAll = () => models.User.find({}, PUBLIC_FIELDS)
 
+  const getFiltered = (filter = {}) => models.User.find(filter, PUBLIC_FIELDS)
+
   const get = (filter = {}) => models.User.findOne(filter, PUBLIC_FIELDS).then(ensureUser)
 
   const getById = id => models.User.findById(id, PUBLIC_FIELDS)
@@ -41,6 +43,7 @@ const Commands = (service, models, client) => {
   return {
     add,
     getAll,
+    getFiltered,
     get,
     getById,
     remove,

--- a/lib/models/ability.js
+++ b/lib/models/ability.js
@@ -30,13 +30,22 @@ const Model = service => {
       type: Boolean,
       default: false
     },
+    eventDescription: {
+      type: String
+    },
     action: {
       type: Boolean,
       default: false
     },
+    actionDescription: {
+      type: String
+    },
     state: {
       type: Boolean,
       default: false
+    },
+    stateDescription: {
+      type: String
     },
     type: {
       type: String,

--- a/lib/security/apiKey.js
+++ b/lib/security/apiKey.js
@@ -6,7 +6,7 @@ const Methods = (service, commands) => {
   const getUserByApiKey = utils.GetUserBySecurityToken(commands)
 
   const authenticateAuth = (userData, params, body) => {
-    if (userData._id.toString() === body.user) {
+    if (userData.role === utils.roles.ADMIN || userData._id.toString() === body.user) {
       return Promise.resolve()
     }
     if (userData.role === utils.roles.SERVICE_REGISTERER) {
@@ -26,7 +26,7 @@ const Methods = (service, commands) => {
       .then(securityToken => Promise.resolve(securityToken.token))
     )
 
-  const revokeAuth = utils.AuthOperation((userData, params, body) => getUserByApiKey(body.apiKey))
+  const revokeAuth = utils.AdminOrOwner((userData, params, body) => getUserByApiKey(body.apiKey))
 
   const revokeHandler = (params, body, res, userData) => commands.securityToken.remove(body.apiKey)
 

--- a/lib/security/apiKey.js
+++ b/lib/security/apiKey.js
@@ -6,7 +6,7 @@ const Methods = (service, commands) => {
   const getUserByApiKey = utils.GetUserBySecurityToken(commands)
 
   const authenticateAuth = (userData, params, body) => {
-    if( userData._id.toString() === body.user) {
+    if (userData._id.toString() === body.user) {
       return Promise.resolve()
     }
     if (userData.role === utils.roles.SERVICE_REGISTERER) {
@@ -23,8 +23,8 @@ const Methods = (service, commands) => {
 
   const authenticateHandler = (params, body) => commands.user.getById(body.user)
     .then(user => commands.securityToken.add(user, utils.API_KEY)
-    .then(securityToken => Promise.resolve(securityToken.token))
-  )
+      .then(securityToken => Promise.resolve(securityToken.token))
+    )
 
   const revokeAuth = utils.AuthOperation((userData, params, body) => getUserByApiKey(body.apiKey))
 

--- a/lib/security/apiKey.js
+++ b/lib/security/apiKey.js
@@ -5,13 +5,24 @@ const utils = require('./utils')
 const Methods = (service, commands) => {
   const getUserByApiKey = utils.GetUserBySecurityToken(commands)
 
-  const authenticateAuth = utils.AuthOperation((userData, params, body) => Promise.resolve({
-    name: body.user
-  }))
+  const authenticateAuth = (userData, params, body) => {
+    if( userData._id.toString() === body.user) {
+      return Promise.resolve()
+    }
+    if (userData.role === utils.roles.SERVICE_REGISTERER) {
+      return commands.user.getById(body.user)
+        .then(userData => {
+          if (userData.role === utils.roles.SERVICE) {
+            return Promise.resolve()
+          }
+          return Promise.reject(new service.errors.Forbidden())
+        })
+    }
+    return Promise.reject(new service.errors.Forbidden())
+  }
 
-  const authenticateHandler = (params, body) => commands.user.get({
-    name: body.user
-  }).then(user => commands.securityToken.add(user, utils.API_KEY)
+  const authenticateHandler = (params, body) => commands.user.getById(body.user)
+    .then(user => commands.securityToken.add(user, utils.API_KEY)
     .then(securityToken => Promise.resolve(securityToken.token))
   )
 

--- a/lib/security/jwt.js
+++ b/lib/security/jwt.js
@@ -19,7 +19,7 @@ const Methods = (service, commands) => {
   const authenticateHandler = (params, body) => body.refreshToken ? getUserByRefreshToken(body.refreshToken)
     .then(userData => ({userData})) : getUserByCredentials(body)
 
-  const revokeAuth = utils.AuthOperation((userData, params, body) => getUserByRefreshToken(body.refreshToken))
+  const revokeAuth = utils.AdminOrOwner((userData, params, body) => getUserByRefreshToken(body.refreshToken))
 
   const revokeHandler = (params, body) => commands.securityToken.remove(body.refreshToken)
 

--- a/lib/security/utils.js
+++ b/lib/security/utils.js
@@ -39,7 +39,7 @@ const AuthOperation = getOwner => (userData, params, body) => {
   }
   return getOwner(userData, params, body)
     .then(resourceUserData => {
-      return resourceUserData.name === userData.name ? Promise.resolve() : Promise.reject(new Error())
+      return resourceUserData._id === userData._id ? Promise.resolve() : Promise.reject(new Error())
     })
 }
 

--- a/lib/security/utils.js
+++ b/lib/security/utils.js
@@ -20,7 +20,7 @@ const SERVICE_REGISTERER_USER = {
   role: roles.SERVICE_REGISTERER
 }
 
-const API_KEY = 'apikey'
+const API_KEY = 'apiKey'
 const JWT = 'jwt'
 
 const cleanUserData = userData => ({
@@ -33,13 +33,13 @@ const cleanUserData = userData => ({
 const GetUserBySecurityToken = commands => securityToken => commands.securityToken.getUser(securityToken)
   .then(userData => Promise.resolve(cleanUserData(userData)))
 
-const AuthOperation = getOwner => (userData, params, body) => {
+const AdminOrOwner = getOwner => (userData, params, body) => {
   if (userData.role === roles.ADMIN) {
     return true
   }
   return getOwner(userData, params, body)
     .then(resourceUserData => {
-      return resourceUserData._id === userData._id ? Promise.resolve() : Promise.reject(new Error())
+      return resourceUserData._id.toString() === userData._id.toString() ? Promise.resolve() : Promise.reject(new Error())
     })
 }
 
@@ -53,6 +53,6 @@ module.exports = {
   JWT,
   cleanUserData,
   GetUserBySecurityToken,
-  AuthOperation,
+  AdminOrOwner,
   onlyAdmin
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@pm2/agent": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-0.5.15.tgz",
-      "integrity": "sha512-sb6qHVPXQ8CJWNFHFPvAyMv0Xy1PNcIHTWEdyqBgPhh10iwNXWjw9y6aAESwEEW0/GZ7gOQIYux2QzpsbV/tbw==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-0.5.16.tgz",
+      "integrity": "sha512-8oDUY0N21LFULtr9G0/u4vyIRtG2UM9dvEmrDV6h3iqP/7ykqnJ9JnB3MOsMEL6+EsA0Mwf2A4QbHvItwO3mzQ==",
       "requires": {
         "async": "^2.6.0",
         "eventemitter2": "^5.0.1",
@@ -71,9 +71,9 @@
       }
     },
     "@pm2/js-api": {
-      "version": "0.5.24",
-      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.5.24.tgz",
-      "integrity": "sha512-Cx/04MycR5CEDjf/PvItsKo0AGBHpHrKn0DqHBCAkOdjMcfvNThD6jUqA1NXDH7/JJE6OtJSpx3TFiV1rk+Jlg==",
+      "version": "0.5.27",
+      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.5.27.tgz",
+      "integrity": "sha512-6XYvKCu3vAGUdRPVHtZQLXUs7GR4Xpj7guE55f5cK43WTsnsg2HHzKSo3lvNPm68cml5cFA7RrPJEmkyUXouLg==",
       "requires": {
         "async": "^2.4.1",
         "axios": "^0.16.2",
@@ -597,9 +597,9 @@
       }
     },
     "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
     },
     "blessed": {
       "version": "0.1.81",
@@ -1287,9 +1287,9 @@
       }
     },
     "domapic-base": {
-      "version": "1.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/domapic-base/-/domapic-base-1.0.0-beta.8.tgz",
-      "integrity": "sha512-h6vkSRU0zDyNAzafjUMo8cn4nqRrWKELgqGgBL6ubmvy7jW3ho3/Dwjuh8wN3DCd5VA2Tp2DtjWHLq10+FZXNw==",
+      "version": "1.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/domapic-base/-/domapic-base-1.0.0-beta.10.tgz",
+      "integrity": "sha512-s6TDGB8KcJc9rCWcrspVPLzE6d4SmD2mvi2M7SZaozRpOCyLZA75x/uIf1f6hhTtRZieXGscWr5q5ix+/+CPaQ==",
       "requires": {
         "bluebird": "3.5.1",
         "body-parser": "1.18.3",
@@ -2137,11 +2137,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
-      "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
+      "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "=3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -4216,9 +4216,9 @@
       "dev": true
     },
     "needle": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.2.tgz",
-      "integrity": "sha512-mW7W8dKuVYefCpNzE3Z7xUmPI9wSrSL/1qH31YGMxmSOAnjatS3S9Zv3cmiHrhx3Jkp1SrWWBdOFXjfF48Uq3A==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
       "requires": {
         "debug": "^2.1.2",
         "iconv-lite": "^0.4.4",
@@ -4751,12 +4751,17 @@
           }
         },
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -4772,12 +4777,17 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -4790,12 +4800,17 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -5005,14 +5020,13 @@
       }
     },
     "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
       }
     },
     "rechoir": {
@@ -5334,11 +5348,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "set-value": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "coveralls": "cat ./.coverage/unit/lcov.info | coveralls"
   },
   "dependencies": {
-    "domapic-base": "1.0.0-beta.8",
+    "domapic-base": "1.0.0-beta.10",
     "inquirer": "6.2.0",
     "inquirer-autocomplete-prompt": "1.0.1",
     "md5": "2.2.1",

--- a/test/functional/specs/security-tokens-api.specs.js
+++ b/test/functional/specs/security-tokens-api.specs.js
@@ -91,7 +91,7 @@ test.describe('security tokens api', function () {
       })
 
       test.it('should return all existant security tokens aplying received type filter', () => {
-        const type = 'apikey'
+        const type = 'apiKey'
         return getAuthTokens({
           type
         }).then(response => {
@@ -191,7 +191,7 @@ test.describe('security tokens api', function () {
 
       test.it('should return a forbidden error if requested user has not a "service" role', () => {
         return getAuthTokens({
-          type: 'apikey',
+          type: 'apiKey',
           user: operatorUserId
         }).then((response) => {
           return Promise.all([
@@ -201,9 +201,9 @@ test.describe('security tokens api', function () {
         })
       })
 
-      test.it('should return tokens data if requested user has "service" role and requested type is "apikey"', () => {
+      test.it('should return tokens data if requested user has "service" role and requested type is "apiKey"', () => {
         return getAuthTokens({
-          type: 'apikey',
+          type: 'apiKey',
           user: serviceUserId
         }).then((response) => {
           return Promise.all([
@@ -213,7 +213,7 @@ test.describe('security tokens api', function () {
         })
       })
 
-      test.it('should return a forbidden error if requested type if different to "apikey"', () => {
+      test.it('should return a forbidden error if requested type if different to "apiKey"', () => {
         return getAuthTokens({
           type: 'jwt',
           user: serviceUserId

--- a/test/functional/specs/service-registerer-api-key.specs.js
+++ b/test/functional/specs/service-registerer-api-key.specs.js
@@ -16,6 +16,36 @@ test.describe('server', function () {
     const authenticator = utils.Authenticator()
     let apiKey
 
+    const fooServiceUser = {
+      name: 'foo-service-name',
+      role: 'service'
+    }
+
+    const getUsers = function (query) {
+      return utils.request('/users', {
+        method: 'GET',
+        query,
+        ...authenticator.credentials()
+      })
+    }
+
+    const getUserMe = function () {
+      return utils.request(`/users/me`, {
+        method: 'GET',
+        ...authenticator.credentials()
+      })
+    }
+
+    const addApiKey = user => {
+      return utils.request('/auth/apikey', {
+        method: 'POST',
+        body: {
+          user
+        },
+        ...authenticator.credentials()
+      })
+    }
+
     test.before(() => {
       return testUtils.logs.combined('controller')
         .then((log) => {
@@ -25,12 +55,41 @@ test.describe('server', function () {
     })
 
     test.it('should be able to add service users', () => {
-      return utils.createUser(authenticator, {
-        name: 'foo-service-name',
-        role: 'service'
-      }).then((response) => {
+      return utils.createUser(authenticator, fooServiceUser).then((response) => {
         return test.expect(response.statusCode).to.equal(201)
       })
+    })
+
+    test.it('should be able to add apiKeys for service users', () => {
+      return utils.ensureUserAndDoLogin(authenticator, fooServiceUser)
+        .then(() => {
+          return getUserMe().then((response) => {
+            const userId = response.body._id
+            authenticator.loginApiKey('service-registerer', apiKey)
+            return addApiKey(userId).then((response) => {
+              return Promise.all([
+                test.expect(response.statusCode).to.equal(200),
+                test.expect(response.body.apiKey).to.not.be.undefined()
+              ])
+            })
+          })
+        })
+    })
+
+    test.it('should not be able to add apiKeys for another users', () => {
+      return utils.doLogin(authenticator)
+        .then(() => {
+          return getUserMe().then((response) => {
+            const userId = response.body._id
+            authenticator.loginApiKey('service-registerer', apiKey)
+            return addApiKey(userId).then((response) => {
+              return Promise.all([
+                test.expect(response.body.message).to.contain('Not authorized'),
+                test.expect(response.statusCode).to.equal(403)
+              ])
+            })
+          })
+        })
     })
 
     test.it('should not be able to add admin users', () => {
@@ -40,6 +99,23 @@ test.describe('server', function () {
         password: 'foo-password',
         role: 'admin'
       }).then((response) => {
+        return Promise.all([
+          test.expect(response.body.message).to.contain('Not authorized'),
+          test.expect(response.statusCode).to.equal(403)
+        ])
+      })
+    })
+
+    test.it('should be able to get service users', () => {
+      return getUsers({
+        role: 'service'
+      }).then((response) => {
+        return test.expect(response.statusCode).to.equal(200)
+      })
+    })
+
+    test.it('should not be able to get users without role filter', () => {
+      return getUsers().then((response) => {
         return Promise.all([
           test.expect(response.body.message).to.contain('Not authorized'),
           test.expect(response.statusCode).to.equal(403)

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -156,7 +156,7 @@ test.describe('users api', function () {
           role: 'admidsn'
         }).then((response) => {
           return Promise.all([
-            test.expect(response.body.message).to.contain('is not one of enum values: admin,operator,service,service-registerer,plugin'),
+            test.expect(response.body.message).to.contain('is not one of enum values: admin,operator,service,plugin,service-registerer'),
             test.expect(response.statusCode).to.equal(422)
           ])
         })

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -7,9 +7,10 @@ test.describe('users api', function () {
   let authenticator = utils.Authenticator()
   let adminUserId
 
-  const getUsers = function () {
+  const getUsers = function (query) {
     return utils.request('/users', {
       method: 'GET',
+      query,
       ...authenticator.credentials()
     })
   }
@@ -375,6 +376,16 @@ test.describe('users api', function () {
           password: 'foo'
         }).then(response => {
           return test.expect(response.statusCode).to.equal(403)
+        })
+      })
+    })
+
+    test.describe('get users', () => {
+      test.it('should return users if query role has "service" value', () => {
+        return getUsers({
+          role: 'service'
+        }).then(response => {
+          return test.expect(response.statusCode).to.equal(200)
         })
       })
     })

--- a/test/unit/lib/Commands.specs.js
+++ b/test/unit/lib/Commands.specs.js
@@ -29,6 +29,7 @@ test.describe('Commands', () => {
       return test.expect(commands.user).to.have.all.keys(
         'add',
         'getAll',
+        'getFiltered',
         'get',
         'getById',
         'init',

--- a/test/unit/lib/api/abilities.specs.js
+++ b/test/unit/lib/api/abilities.specs.js
@@ -59,7 +59,7 @@ test.describe('abilities api', () => {
 
         return operations.getAbility.handler({
           path: {
-            _id: fooId
+            id: fooId
           }})
           .then((result) => {
             return Promise.all([
@@ -210,7 +210,7 @@ test.describe('abilities api', () => {
       test.it('should call to update ability, passing the received id and body', () => {
         return operations.updateAbility.handler({
           path: {
-            _id: fooId
+            id: fooId
           }
         }, fooBody, response)
           .then((result) => {
@@ -221,7 +221,7 @@ test.describe('abilities api', () => {
       test.it('should add a 204 header to response', () => {
         return operations.updateAbility.handler({
           path: {
-            _id: fooId
+            id: fooId
           }
         }, fooBody, response)
           .then(() => {
@@ -232,7 +232,7 @@ test.describe('abilities api', () => {
       test.it('should set the response header with the ability id', () => {
         return operations.updateAbility.handler({
           path: {
-            _id: fooId
+            id: fooId
           }
         }, fooBody, response)
           .then(() => {
@@ -243,7 +243,7 @@ test.describe('abilities api', () => {
       test.it('should resolve the promise with no value', () => {
         return operations.updateAbility.handler({
           path: {
-            _id: fooId
+            id: fooId
           }
         }, fooBody, response)
           .then((result) => {

--- a/test/unit/lib/api/securityTokens.specs.js
+++ b/test/unit/lib/api/securityTokens.specs.js
@@ -67,7 +67,7 @@ test.describe('securityTokens api', () => {
             role: 'service'
           })
           return operations.getSecurityTokens.auth({ role: 'service-registerer', _id: '' }, { query: {
-            type: 'apikey',
+            type: 'apiKey',
             user: 'foo-id'
           }}, {}).then(result => {
             return test.expect(true).to.be.true()
@@ -81,7 +81,7 @@ test.describe('securityTokens api', () => {
           })
           baseMocks.stubs.service.errors.Forbidden.returns(forbiddenError)
           return operations.getSecurityTokens.auth({ role: 'service-registerer', _id: '' }, { query: {
-            type: 'apikey',
+            type: 'apiKey',
             user: 'foo-id'
           }}, {}).then(result => {
             return test.assert.fail()

--- a/test/unit/lib/api/services.specs.js
+++ b/test/unit/lib/api/services.specs.js
@@ -46,7 +46,7 @@ test.describe('services api', () => {
 
         return operations.getService.handler({
           path: {
-            _id: fooId
+            id: fooId
           }})
           .then((result) => {
             return Promise.all([
@@ -138,7 +138,7 @@ test.describe('services api', () => {
       const fooUserId = 'foo-user-id'
       const fooParams = {
         path: {
-          _id: 'foo-service-id'
+          id: 'foo-service-id'
         }
       }
 
@@ -197,7 +197,7 @@ test.describe('services api', () => {
       test.it('should call to update service, passing the received name and body', () => {
         return operations.updateService.handler({
           path: {
-            _id: fooId
+            id: fooId
           }
         }, fooBody, response)
           .then((result) => {
@@ -208,7 +208,7 @@ test.describe('services api', () => {
       test.it('should add a 204 header to response', () => {
         return operations.updateService.handler({
           path: {
-            _id: fooId
+            id: fooId
           }
         }, fooBody, response)
           .then(() => {
@@ -219,7 +219,7 @@ test.describe('services api', () => {
       test.it('should set the response header with the service name', () => {
         return operations.updateService.handler({
           path: {
-            _id: fooId
+            id: fooId
           }
         }, fooBody, response)
           .then(() => {
@@ -230,7 +230,7 @@ test.describe('services api', () => {
       test.it('should resolve the promise with no value', () => {
         return operations.updateService.handler({
           path: {
-            _id: fooId
+            id: fooId
           }
         }, fooBody, response)
           .then((result) => {

--- a/test/unit/lib/commands/User.mocks.js
+++ b/test/unit/lib/commands/User.mocks.js
@@ -9,6 +9,7 @@ const Mock = function () {
   const commandsStubs = {
     add: sandbox.stub().usingPromise().resolves(),
     getAll: sandbox.stub().usingPromise().resolves(),
+    getFiltered: sandbox.stub().usingPromise().resolves(),
     get: sandbox.stub().usingPromise().resolves(),
     getById: sandbox.stub().usingPromise().resolves(),
     remove: sandbox.stub().usingPromise().resolves(),

--- a/test/unit/lib/commands/composed.specs.js
+++ b/test/unit/lib/commands/composed.specs.js
@@ -60,7 +60,7 @@ test.describe('composed commands', () => {
           userCommandsMocks.stubs.commands.get.resolves(fooRegistererUser)
           return commands.initUsers()
             .then(() => {
-              return test.expect(securityTokenCommandsMocks.stubs.commands.add).to.have.been.calledWith(fooRegistererUser, 'apikey')
+              return test.expect(securityTokenCommandsMocks.stubs.commands.add).to.have.been.calledWith(fooRegistererUser, 'apiKey')
             })
         })
       })
@@ -85,7 +85,7 @@ test.describe('composed commands', () => {
           securityTokenCommandsMocks.stubs.commands.get.rejects(new Error())
           return commands.initUsers()
             .then(() => {
-              return test.expect(securityTokenCommandsMocks.stubs.commands.add).to.have.been.calledWith(fooRegistererUser, 'apikey')
+              return test.expect(securityTokenCommandsMocks.stubs.commands.add).to.have.been.calledWith(fooRegistererUser, 'apiKey')
             })
         })
       })

--- a/test/unit/lib/commands/user.specs.js
+++ b/test/unit/lib/commands/user.specs.js
@@ -80,6 +80,37 @@ test.describe('user commands', () => {
       })
     })
 
+    test.describe('getFiltered method', () => {
+      const fooFilter = {
+        _role: 'foo-role'
+      }
+      const fooUsers = [{
+        token: 'foo'
+      }]
+
+      test.it('should call to find users and return the result', () => {
+        modelsMocks.stubs.User.find.resolves(fooUsers)
+        return commands.getFiltered(fooFilter)
+          .then((result) => {
+            return Promise.all([
+              test.expect(result).to.equal(fooUsers),
+              test.expect(modelsMocks.stubs.User.find).to.have.been.calledWith(fooFilter)
+            ])
+          })
+      })
+
+      test.it('should call to find users with an empty filter if it is not provided', () => {
+        modelsMocks.stubs.User.find.resolves(fooUsers)
+        return commands.getFiltered()
+          .then((result) => {
+            return Promise.all([
+              test.expect(result).to.equal(fooUsers),
+              test.expect(modelsMocks.stubs.User.find).to.have.been.calledWith({})
+            ])
+          })
+      })
+    })
+
     test.describe('get method', () => {
       test.it('should call to user model get method, and return the result', () => {
         const fooResult = 'foo'

--- a/test/unit/lib/security/apiKey.specs.js
+++ b/test/unit/lib/security/apiKey.specs.js
@@ -55,7 +55,39 @@ test.describe('apiKey security', () => {
         })
       })
 
-      test.describe('when user is not an administrator', () => {
+      test.describe('when user has service-registerer role', () => {
+        test.it('should resolve the promise if provided user has service role', () => {
+          const fooUserData = {
+            role: 'service'
+          }
+          commandsMocks.stubs.user.getById.resolves(fooUserData)
+          return security.authenticateAuth({
+            role: 'service-registerer',
+            _id: 'foo-user-id'
+          }, {}, {user: 'foo-id'})
+            .then(() => {
+              return test.expect(true).to.be.true()
+            })
+        })
+
+        test.it('should reject the promise if provided has not service role', () => {
+          const fooUserData = {
+            role: 'operator'
+          }
+          commandsMocks.stubs.user.getById.resolves(fooUserData)
+          return security.authenticateAuth({ 
+            role: 'service-registerer',
+            _id: 'foo-user-id'
+          }, {}, {user: 'foo-id'})
+            .then(() => {
+              return test.assert.fail()
+            }, () => {
+              return test.expect(true).to.be.true()
+            })
+        })
+      })
+
+      test.describe('when user is not an administrator or service-registerer', () => {
         test.it('should resolve the promise if provided user matches with logged user name', () => {
           return security.authenticateAuth({_id: 'foo-id'}, {}, {user: 'foo-id'})
             .then(() => {
@@ -63,7 +95,7 @@ test.describe('apiKey security', () => {
             })
         })
 
-        test.it('should reject the promise if provided user does not match with logged user id', () => {
+        test.it('should reject the promise if provided user does not match with logged user', () => {
           return security.authenticateAuth({_id: 'foo-different-id'}, {}, {user: 'foo-other-id'})
             .then(() => {
               return test.assert.fail()

--- a/test/unit/lib/security/apiKey.specs.js
+++ b/test/unit/lib/security/apiKey.specs.js
@@ -75,7 +75,7 @@ test.describe('apiKey security', () => {
             role: 'operator'
           }
           commandsMocks.stubs.user.getById.resolves(fooUserData)
-          return security.authenticateAuth({ 
+          return security.authenticateAuth({
             role: 'service-registerer',
             _id: 'foo-user-id'
           }, {}, {user: 'foo-id'})

--- a/test/unit/lib/security/jwt.specs.js
+++ b/test/unit/lib/security/jwt.specs.js
@@ -133,9 +133,9 @@ test.describe('jwt security', () => {
       test.describe('when user is not an administrator', () => {
         test.it('should get user data from refresh token and resolve the promise if the token belongs to himself', () => {
           commandsMocks.stubs.securityToken.getUser.resolves({
-            email: 'fooEmail'
+            _id: 'foo-id'
           })
-          return security.revokeAuth({email: 'fooEmail'}, {}, {refreshToken: 'fooRefreshToken'})
+          return security.revokeAuth({_id: 'foo-id'}, {}, {refreshToken: 'fooRefreshToken'})
             .then(() => {
               return test.expect(true).to.be.true()
             })
@@ -143,9 +143,9 @@ test.describe('jwt security', () => {
 
         test.it('should get user data from refresh token and reject the promise if the token do not belongs to himself', () => {
           commandsMocks.stubs.securityToken.getUser.resolves({
-            name: 'foo-name'
+            _id: 'foo-id'
           })
-          return security.revokeAuth({name: 'foo-different-name'}, {}, {refreshToken: 'fooRefreshToken'})
+          return security.revokeAuth({_id: 'foo-different-id'}, {}, {refreshToken: 'fooRefreshToken'})
             .then(() => {
               return test.assert.fail()
             }, () => {

--- a/test/unit/lib/security/utils.specs.js
+++ b/test/unit/lib/security/utils.specs.js
@@ -60,7 +60,7 @@ test.describe('security utils', () => {
     })
   })
 
-  test.describe('AuthOperation instance', () => {
+  test.describe('AdminOrOwner instance', () => {
     let sandbox
     let authOperation
     let getOwner
@@ -68,9 +68,9 @@ test.describe('security utils', () => {
     test.beforeEach(() => {
       sandbox = test.sinon.createSandbox()
       getOwner = sandbox.stub().usingPromise().resolves({
-        name: 'foo-name'
+        _id: 'foo-id'
       })
-      authOperation = utils.AuthOperation(getOwner)
+      authOperation = utils.AdminOrOwner(getOwner)
     })
 
     test.afterEach(() => {
@@ -78,7 +78,7 @@ test.describe('security utils', () => {
     })
 
     test.it('should call to provided getOwner function, passing arguments to it', () => {
-      const args = [{ name: 'foo-name' }, 'foo2', 'foo3']
+      const args = [{ _id: 'foo-id' }, 'foo2', 'foo3']
       return authOperation(...args)
         .then(result => {
           return test.expect(getOwner).to.have.been.calledWith(...args)
@@ -90,8 +90,8 @@ test.describe('security utils', () => {
       return test.expect(authOperation(...args)).to.be.true()
     })
 
-    test.it('should return a rejected promise if provided user name is not equal to name returned by getOwner function', () => {
-      const args = [{ name: 'foo-different-name' }, 'foo2', 'foo3']
+    test.it('should return a rejected promise if provided user _id is not equal to _id returned by getOwner function', () => {
+      const args = [{ _id: 'foo-different-id' }, 'foo2', 'foo3']
       return authOperation(...args)
         .then(result => {
           return test.assert.fail()


### PR DESCRIPTION
- Change apiKey by camelcase in all code.
- Allow service-registerer users to get users with service role.
- Allow admin users to add apiKeys for any user.
- Add role filter to get users api. 
- Use only ids as get params in apis.
- Allow service-registerer users to create apiKeys for service users