### PR TITLE
Add integer and float data types to openapi

### DIFF
--- a/lib/api/abilities.json
+++ b/lib/api/abilities.json
@@ -66,7 +66,7 @@
           "type": {
             "description": "Type of ability data",
             "type": "string",
-            "enum": ["string", "boolean", "number"]
+            "enum": ["string", "boolean", "number", "integer", "float"]
           },
           "format": {
             "description": "Format of ability data",
@@ -187,7 +187,7 @@
           "type": {
             "description": "Type of ability data",
             "type": "string",
-            "enum": ["string", "boolean", "number"]
+            "enum": ["string", "boolean", "number", "integer", "float"]
           },
           "format": {
             "description": "Format of ability data",


### PR DESCRIPTION
- Allow "integer" and "float" as data types for abilities in api.
