### PR TITLE
Fix operation events.

### DIFF
--- a/lib/api/abilities.js
+++ b/lib/api/abilities.js
@@ -37,7 +37,7 @@ const Operations = (service, commands) => {
       handler: (params, body, res) => commands.ability.update(params.path.id, body).then(abilityData => {
         res.status(204)
         res.header(LOCATION, `${LOCATION_ROOT}${abilityData._id}`)
-        events.plugin(EVENT_ENTITY, 'update', abilityData)
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.UPDATE, abilityData)
         return Promise.resolve()
       })
     },
@@ -46,7 +46,7 @@ const Operations = (service, commands) => {
       handler: (params, body, res, userData) => commands.ability.add(userData, body).then(abilityData => {
         res.status(201)
         res.header(LOCATION, `${LOCATION_ROOT}${abilityData._id}`)
-        events.plugin(EVENT_ENTITY, 'create', abilityData)
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.CREATE, abilityData)
         return Promise.resolve()
       })
     },
@@ -54,7 +54,7 @@ const Operations = (service, commands) => {
       auth: onlyOwner,
       handler: (params, body, res, userData) => commands.ability.remove(params.path.id).then(() => {
         res.status(204)
-        events.plugin(EVENT_ENTITY, 'delete', {
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.DELETE, {
           _id: params.path.id
         })
         return Promise.resolve()
@@ -64,7 +64,7 @@ const Operations = (service, commands) => {
       handler: (params, body, res) => commands.composed.dispatchAbilityAction(params.path.id, body).then(serviceResponse => {
         res.status(201)
         res.header(LOCATION, `${LOCATION_ROOT}${params.path.id}/state`)
-        events.plugin(EVENT_ENTITY, 'action', {
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.ACTION, {
           _id: params.path.id,
           ...body
         })
@@ -79,7 +79,7 @@ const Operations = (service, commands) => {
       handler: (params, body, res) => commands.composed.triggerAbilityEvent(params.path.id, body).then(() => {
         res.status(201)
         res.header(LOCATION, `${LOCATION_ROOT}${params.path.id}/state`)
-        events.plugin(EVENT_ENTITY, 'event', {
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.EVENT, {
           _id: params.path.id,
           ...body
         })

--- a/lib/api/services.js
+++ b/lib/api/services.js
@@ -30,7 +30,7 @@ const Operations = (service, commands) => ({
     handler: (params, body, res) => commands.service.update(params.path.id, body).then(serviceData => {
       res.status(204)
       res.header('location', `/api/services/${serviceData._id}`)
-      events.plugin(EVENT_ENTITY, 'update', serviceData)
+      events.plugin(EVENT_ENTITY, events.OPERATIONS.UPDATE, serviceData)
       return Promise.resolve()
     })
   },
@@ -40,7 +40,7 @@ const Operations = (service, commands) => ({
       .then(serviceData => {
         res.status(201)
         res.header('location', `/api/services/${serviceData._id}`)
-        events.plugin(EVENT_ENTITY, 'create', serviceData)
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.CREATE, serviceData)
         return Promise.resolve()
       })
   }

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -32,7 +32,7 @@ const Operations = (service, commands) => {
         .then(user => {
           res.status(201)
           res.header('location', `/api/users/${user._id}`)
-          events.plugin(EVENT_ENTITY, 'create', user)
+          events.plugin(EVENT_ENTITY, events.OPERATIONS.CREATE, user)
           return Promise.resolve()
         })
     },

--- a/lib/commands/service.js
+++ b/lib/commands/service.js
@@ -25,7 +25,7 @@ const Commands = (service, models, client) => {
       .then(() => Promise.resolve(newService))
   }
 
-  const getFiltered = (filter = {}) => models.Service.find(filter, PUBLIC_FIELDS)
+  const getFiltered = (filter = {}, options = {}) => models.Service.find(filter, options.allFields ? undefined : PUBLIC_FIELDS)
 
   const get = (filter = {}) => models.Service.findOne(filter, PUBLIC_FIELDS).then(ensureService)
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -5,6 +5,13 @@ const events = require('events')
 const emitter = new events.EventEmitter()
 
 const PLUGIN = 'plugin'
+const OPERATIONS = {
+  CREATE: 'created',
+  DELETE: 'deleted',
+  UPDATE: 'updated',
+  ACTION: 'action',
+  EVENT: 'event'
+}
 
 const plugin = (entity, operation, data) => {
   emitter.emit(PLUGIN, {
@@ -15,7 +22,8 @@ const plugin = (entity, operation, data) => {
 }
 
 module.exports = {
-  emitter,
   PLUGIN,
+  OPERATIONS,
+  emitter,
   plugin
 }

--- a/lib/pluginsHandler.js
+++ b/lib/pluginsHandler.js
@@ -7,6 +7,8 @@ const init = (service, commands, client) => {
     const sendData = service => client.sendEvent(service, eventData)
     commands.service.getFiltered({
       type: 'plugin'
+    }, {
+      allFields: true
     }).then(services => {
       services.map(sendData)
     })

--- a/test/functional/specs/abilities-api.specs.js
+++ b/test/functional/specs/abilities-api.specs.js
@@ -239,7 +239,7 @@ test.describe('abilities api', function () {
         })
 
         test.it('should have sent ability creation event to registered plugins', () => {
-          return utils.expectEvent('ability:create', entityId, pluginId)
+          return utils.expectEvent('ability:created', entityId, pluginId)
         })
       })
     })
@@ -333,7 +333,7 @@ test.describe('abilities api', function () {
       })
 
       test.it('should have sent ability update event to registered plugins', () => {
-        return utils.expectEvent('ability:update', moduleUserAbility._id, pluginId)
+        return utils.expectEvent('ability:updated', moduleUserAbility._id, pluginId)
       })
     })
   })
@@ -404,7 +404,7 @@ test.describe('abilities api', function () {
       })
 
       test.it('should have sent ability delete event to registered plugins', () => {
-        return utils.expectEvent('ability:delete', moduleUserAbility._id, pluginId)
+        return utils.expectEvent('ability:deleted', moduleUserAbility._id, pluginId)
       })
     })
   })

--- a/test/functional/specs/services-api.specs.js
+++ b/test/functional/specs/services-api.specs.js
@@ -216,7 +216,7 @@ test.describe('services api', function () {
       })
 
       test.it('should have sent service creation event to registered plugins', () => {
-        return utils.expectEvent('service:create', entityId, pluginId)
+        return utils.expectEvent('service:created', entityId, pluginId)
       })
 
       test.it('should return a bad data error if one user tries to add more than one service', () => {
@@ -420,7 +420,7 @@ test.describe('services api', function () {
       })
 
       test.it('should have sent service update event to registered plugins', () => {
-        return utils.expectEvent('service:update', moduleUserService._id, pluginId)
+        return utils.expectEvent('service:updated', moduleUserService._id, pluginId)
       })
 
       test.it('should update all provided service data even when url is same than before', () => {

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -208,7 +208,7 @@ test.describe('users api', function () {
       })
 
       test.it('should have sent user creation event to registered plugins', () => {
-        return utils.expectEvent('user:create', entityId, pluginId)
+        return utils.expectEvent('user:created', entityId, pluginId)
       })
 
       test.it('should return a bad data error if an already existant email is provided', () => {

--- a/test/unit/lib/api/abilities.specs.js
+++ b/test/unit/lib/api/abilities.specs.js
@@ -144,7 +144,7 @@ test.describe('abilities api', () => {
       test.it('should emit a plugin event', () => {
         return operations.addAbility.handler({}, fooBody, response, fooUserData)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'create', fooAbility)
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'created', fooAbility)
           })
       })
 
@@ -257,7 +257,7 @@ test.describe('abilities api', () => {
           }
         }, fooBody, response)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'update', fooAbility)
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'updated', fooAbility)
           })
       })
 
@@ -358,7 +358,7 @@ test.describe('abilities api', () => {
           }
         }, {}, response)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'delete', {
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'deleted', {
               _id: fooId
             })
           })

--- a/test/unit/lib/api/services.specs.js
+++ b/test/unit/lib/api/services.specs.js
@@ -173,7 +173,7 @@ test.describe('services api', () => {
       test.it('should emit a plugin event', () => {
         return operations.addService.handler({}, fooBody, response, fooUserData)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('service', 'create', fooService)
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('service', 'created', fooService)
           })
       })
 
@@ -285,7 +285,7 @@ test.describe('services api', () => {
           }
         }, fooBody, response)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('service', 'update', fooService)
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('service', 'updated', fooService)
           })
       })
 

--- a/test/unit/lib/api/users.specs.js
+++ b/test/unit/lib/api/users.specs.js
@@ -415,7 +415,7 @@ test.describe('users api', () => {
       test.it('should emit a plugin event', () => {
         return operations.addUser.handler({}, fooBody, response)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('user', 'create', fooUser)
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('user', 'created', fooUser)
           })
       })
 

--- a/test/unit/lib/commands/service.specs.js
+++ b/test/unit/lib/commands/service.specs.js
@@ -103,6 +103,19 @@ test.describe('service commands', () => {
             ])
           })
       })
+
+      test.it('should not filter fields if allFields option is received', () => {
+        modelsMocks.stubs.Service.find.resolves(fooServices)
+        return commands.getFiltered({}, {
+          allFields: true
+        })
+          .then((result) => {
+            return Promise.all([
+              test.expect(result).to.equal(fooServices),
+              test.expect(modelsMocks.stubs.Service.find).to.have.been.calledWith({}, undefined)
+            ])
+          })
+      })
     })
 
     test.describe('get method', () => {


### PR DESCRIPTION
- Fix operation events names.
- Avoid filtering service fields when recovering services for sending events.
