### PR TITLE
Release 1.0.0 alpha.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- Send entity operations events to all registered plugins
+- Add type filter to get services api
 ### Changed
+- Allow plugin users to create and get operator users
 ### Fixed
+- Fix role-based permissions in get user api
 ### Removed
 
 ## [1.0.0-alpha.8] - 2018-11-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+### Changed
+### Fixed
+### Removed
+
+## [1.0.0-alpha.9] - 2018-11-18
+### Added
 - Send entity operations events to all registered plugins
 - Add type filter to get services api
 ### Changed
 - Allow plugin users to create and get operator users
 ### Fixed
 - Fix role-based permissions in get user api
-### Removed
 
 ## [1.0.0-alpha.8] - 2018-11-13
 ### Changed

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -39,9 +39,29 @@ const Client = service => {
     )
   }
 
+  const sendEvent = (serviceData, eventData) => {
+    const client = new service.client.Connection(serviceData.url, {
+      apiKey: serviceData.apiKey
+    })
+
+    return service.tracer.debug(templates.sendingEvent({
+      _service: serviceData._id,
+      _id: eventData.data._id,
+      ...eventData
+    })).then(() => client.post(uris.serviceEventHandler(), eventData)
+      .catch(err => {
+        return service.tracer.warn(templates.errorSendingEvent({
+          _service: serviceData._id,
+          ...eventData
+        }), err.message)
+      })
+    )
+  }
+
   return {
     sendAction,
-    getState
+    getState,
+    sendEvent
   }
 }
 

--- a/lib/api/abilities.js
+++ b/lib/api/abilities.js
@@ -37,7 +37,7 @@ const Operations = (service, commands) => {
       handler: (params, body, res) => commands.ability.update(params.path.id, body).then(abilityData => {
         res.status(204)
         res.header(LOCATION, `${LOCATION_ROOT}${abilityData._id}`)
-        events.plugin(EVENT_ENTITY, 'update', abilityData)
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.UPDATE, abilityData)
         return Promise.resolve()
       })
     },
@@ -46,7 +46,7 @@ const Operations = (service, commands) => {
       handler: (params, body, res, userData) => commands.ability.add(userData, body).then(abilityData => {
         res.status(201)
         res.header(LOCATION, `${LOCATION_ROOT}${abilityData._id}`)
-        events.plugin(EVENT_ENTITY, 'create', abilityData)
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.CREATE, abilityData)
         return Promise.resolve()
       })
     },
@@ -54,7 +54,7 @@ const Operations = (service, commands) => {
       auth: onlyOwner,
       handler: (params, body, res, userData) => commands.ability.remove(params.path.id).then(() => {
         res.status(204)
-        events.plugin(EVENT_ENTITY, 'delete', {
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.DELETE, {
           _id: params.path.id
         })
         return Promise.resolve()
@@ -64,7 +64,7 @@ const Operations = (service, commands) => {
       handler: (params, body, res) => commands.composed.dispatchAbilityAction(params.path.id, body).then(serviceResponse => {
         res.status(201)
         res.header(LOCATION, `${LOCATION_ROOT}${params.path.id}/state`)
-        events.plugin(EVENT_ENTITY, 'action', {
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.ACTION, {
           _id: params.path.id,
           ...body
         })
@@ -79,7 +79,7 @@ const Operations = (service, commands) => {
       handler: (params, body, res) => commands.composed.triggerAbilityEvent(params.path.id, body).then(() => {
         res.status(201)
         res.header(LOCATION, `${LOCATION_ROOT}${params.path.id}/state`)
-        events.plugin(EVENT_ENTITY, 'event', {
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.EVENT, {
           _id: params.path.id,
           ...body
         })

--- a/lib/api/abilities.js
+++ b/lib/api/abilities.js
@@ -4,9 +4,11 @@ const { omitBy, isUndefined } = require('lodash')
 
 const definition = require('./abilities.json')
 const { roles } = require('../security/utils')
+const events = require('../events')
 
 const LOCATION = 'location'
 const LOCATION_ROOT = '/api/abilities/'
+const EVENT_ENTITY = 'ability'
 
 const Operations = (service, commands) => {
   const onlyOwner = (userData, params, body) => {
@@ -35,6 +37,7 @@ const Operations = (service, commands) => {
       handler: (params, body, res) => commands.ability.update(params.path.id, body).then(abilityData => {
         res.status(204)
         res.header(LOCATION, `${LOCATION_ROOT}${abilityData._id}`)
+        events.plugin(EVENT_ENTITY, 'update', abilityData)
         return Promise.resolve()
       })
     },
@@ -43,6 +46,7 @@ const Operations = (service, commands) => {
       handler: (params, body, res, userData) => commands.ability.add(userData, body).then(abilityData => {
         res.status(201)
         res.header(LOCATION, `${LOCATION_ROOT}${abilityData._id}`)
+        events.plugin(EVENT_ENTITY, 'create', abilityData)
         return Promise.resolve()
       })
     },
@@ -50,6 +54,9 @@ const Operations = (service, commands) => {
       auth: onlyOwner,
       handler: (params, body, res, userData) => commands.ability.remove(params.path.id).then(() => {
         res.status(204)
+        events.plugin(EVENT_ENTITY, 'delete', {
+          _id: params.path.id
+        })
         return Promise.resolve()
       })
     },
@@ -57,6 +64,10 @@ const Operations = (service, commands) => {
       handler: (params, body, res) => commands.composed.dispatchAbilityAction(params.path.id, body).then(serviceResponse => {
         res.status(201)
         res.header(LOCATION, `${LOCATION_ROOT}${params.path.id}/state`)
+        events.plugin(EVENT_ENTITY, 'action', {
+          _id: params.path.id,
+          ...body
+        })
         return Promise.resolve()
       })
     },
@@ -68,6 +79,10 @@ const Operations = (service, commands) => {
       handler: (params, body, res) => commands.composed.triggerAbilityEvent(params.path.id, body).then(() => {
         res.status(201)
         res.header(LOCATION, `${LOCATION_ROOT}${params.path.id}/state`)
+        events.plugin(EVENT_ENTITY, 'event', {
+          _id: params.path.id,
+          ...body
+        })
         return Promise.resolve()
       })
     }

--- a/lib/api/services.js
+++ b/lib/api/services.js
@@ -1,11 +1,21 @@
 'use strict'
 
+const { omitBy, isUndefined } = require('lodash')
+
 const definition = require('./services.json')
 const { roles } = require('../security/utils')
+const events = require('../events')
+
+const EVENT_ENTITY = 'service'
 
 const Operations = (service, commands) => ({
   getServices: {
-    handler: (params, body, res) => commands.service.getFiltered()
+    handler: (params, body, res) => {
+      const filter = omitBy({
+        type: params.query.type
+      }, isUndefined)
+      return commands.service.getFiltered(filter)
+    }
   },
   getService: {
     handler: (params, body, res) => commands.service.getById(params.path.id)
@@ -20,6 +30,7 @@ const Operations = (service, commands) => ({
     handler: (params, body, res) => commands.service.update(params.path.id, body).then(serviceData => {
       res.status(204)
       res.header('location', `/api/services/${serviceData._id}`)
+      events.plugin(EVENT_ENTITY, 'update', serviceData)
       return Promise.resolve()
     })
   },
@@ -29,6 +40,7 @@ const Operations = (service, commands) => ({
       .then(serviceData => {
         res.status(201)
         res.header('location', `/api/services/${serviceData._id}`)
+        events.plugin(EVENT_ENTITY, 'create', serviceData)
         return Promise.resolve()
       })
   }

--- a/lib/api/services.js
+++ b/lib/api/services.js
@@ -30,7 +30,7 @@ const Operations = (service, commands) => ({
     handler: (params, body, res) => commands.service.update(params.path.id, body).then(serviceData => {
       res.status(204)
       res.header('location', `/api/services/${serviceData._id}`)
-      events.plugin(EVENT_ENTITY, 'update', serviceData)
+      events.plugin(EVENT_ENTITY, events.OPERATIONS.UPDATE, serviceData)
       return Promise.resolve()
     })
   },
@@ -40,7 +40,7 @@ const Operations = (service, commands) => ({
       .then(serviceData => {
         res.status(201)
         res.header('location', `/api/services/${serviceData._id}`)
-        events.plugin(EVENT_ENTITY, 'create', serviceData)
+        events.plugin(EVENT_ENTITY, events.OPERATIONS.CREATE, serviceData)
         return Promise.resolve()
       })
   }

--- a/lib/api/services.json
+++ b/lib/api/services.json
@@ -176,6 +176,17 @@
   "paths": {
     "/services": {
       "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "type": "string",
+              "enum": ["module", "plugin"]
+            },
+            "description": "Service type"
+          }
+        ],
         "tags": ["service"],
         "summary": "Get services",
         "description": "List services",

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -4,41 +4,55 @@ const { omitBy, isUndefined } = require('lodash')
 
 const definition = require('./users.json')
 const { roles } = require('../security/utils')
+const events = require('../events')
 
-const Operations = (service, commands) => ({
-  getUsers: {
-    auth: (userData, params, body) => (
-      userData.role === roles.ADMIN ||
-      (userData.role === roles.SERVICE_REGISTERER && (params.query.role === roles.MODULE || params.query.role === roles.PLUGIN))
-    ),
-    handler: (params, body, res) => {
-      const filter = omitBy({
-        name: params.query.name,
-        role: params.query.role
-      }, isUndefined)
-      return commands.user.getFiltered(filter)
+const EVENT_ENTITY = 'user'
+
+const Operations = (service, commands) => {
+  const rolesBasedAuth = (loggedRole, userRole) => (
+    loggedRole === roles.ADMIN ||
+    (loggedRole === roles.SERVICE_REGISTERER && (userRole === roles.MODULE || userRole === roles.PLUGIN)) ||
+    (loggedRole === roles.PLUGIN && (userRole === roles.OPERATOR))
+  )
+
+  return {
+    getUsers: {
+      auth: (userData, params, body) => rolesBasedAuth(userData.role, params.query && params.query.role),
+      handler: (params, body, res) => {
+        const filter = omitBy({
+          name: params.query.name,
+          role: params.query.role
+        }, isUndefined)
+        return commands.user.getFiltered(filter)
+      }
+    },
+    addUser: {
+      auth: (userData, params, body) => rolesBasedAuth(userData.role, body.role),
+      handler: (params, body, res) => commands.user.add(body)
+        .then(user => {
+          res.status(201)
+          res.header('location', `/api/users/${user._id}`)
+          events.plugin(EVENT_ENTITY, 'create', user)
+          return Promise.resolve()
+        })
+    },
+    getUser: {
+      auth: (userData, params, body) => {
+        return commands.user.getById(params.path.id)
+          .then(user => {
+            if (rolesBasedAuth(userData.role, user.role) || params.path.id === userData._id) {
+              return Promise.resolve()
+            }
+            return Promise.reject(new service.errors.Forbidden())
+          })
+      },
+      handler: (params, body, res) => commands.user.getById(params.path.id)
+    },
+    getUserMe: {
+      handler: (params, body, res, userData) => commands.user.getById(userData._id)
     }
-  },
-  addUser: {
-    auth: (userData, params, body) => (
-      userData.role === roles.ADMIN ||
-      (userData.role === roles.SERVICE_REGISTERER && (body.role === roles.MODULE || body.role === roles.PLUGIN))
-    ),
-    handler: (params, body, res) => commands.user.add(body)
-      .then(user => {
-        res.status(201)
-        res.header('location', `/api/users/${user._id}`)
-        return Promise.resolve()
-      })
-  },
-  getUser: {
-    auth: (userData, params, body) => (userData.role === roles.ADMIN || params.path.id === userData._id),
-    handler: (params, body, res) => commands.user.getById(params.path.id)
-  },
-  getUserMe: {
-    handler: (params, body, res, userData) => commands.user.getById(userData._id)
   }
-})
+}
 
 const openapi = () => [definition]
 

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -32,7 +32,7 @@ const Operations = (service, commands) => {
         .then(user => {
           res.status(201)
           res.header('location', `/api/users/${user._id}`)
-          events.plugin(EVENT_ENTITY, 'create', user)
+          events.plugin(EVENT_ENTITY, events.OPERATIONS.CREATE, user)
           return Promise.resolve()
         })
     },

--- a/lib/commands/service.js
+++ b/lib/commands/service.js
@@ -25,7 +25,7 @@ const Commands = (service, models, client) => {
       .then(() => Promise.resolve(newService))
   }
 
-  const getFiltered = (filter = {}) => models.Service.find(filter, PUBLIC_FIELDS)
+  const getFiltered = (filter = {}, options = {}) => models.Service.find(filter, options.allFields ? undefined : PUBLIC_FIELDS)
 
   const get = (filter = {}) => models.Service.findOne(filter, PUBLIC_FIELDS).then(ensureService)
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -7,6 +7,7 @@ const domapic = require('domapic-base')
 
 const lib = require('./index')
 const options = require('./options')
+const pluginsHandler = require('./pluginsHandler')
 
 const serviceConfig = () => ({
   packagePath: path.resolve(__dirname, '..'),
@@ -21,6 +22,7 @@ const initService = (service) => {
   const commands = lib.Commands(service, models, client)
   const security = lib.Security(service, commands)
   const api = lib.Api(service, commands)
+  pluginsHandler.init(service, commands, client)
 
   const extendOpenApis = () => Promise.map(api.openapis, openapi => service.server.extendOpenApi(openapi))
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const events = require('events')
+
+const emitter = new events.EventEmitter()
+
+const PLUGIN = 'plugin'
+
+const plugin = (entity, operation, data) => {
+  emitter.emit(PLUGIN, {
+    entity,
+    operation,
+    data
+  })
+}
+
+module.exports = {
+  emitter,
+  PLUGIN,
+  plugin
+}

--- a/lib/events.js
+++ b/lib/events.js
@@ -5,6 +5,13 @@ const events = require('events')
 const emitter = new events.EventEmitter()
 
 const PLUGIN = 'plugin'
+const OPERATIONS = {
+  CREATE: 'created',
+  DELETE: 'deleted',
+  UPDATE: 'updated',
+  ACTION: 'action',
+  EVENT: 'event'
+}
 
 const plugin = (entity, operation, data) => {
   emitter.emit(PLUGIN, {
@@ -15,7 +22,8 @@ const plugin = (entity, operation, data) => {
 }
 
 module.exports = {
-  emitter,
   PLUGIN,
+  OPERATIONS,
+  emitter,
   plugin
 }

--- a/lib/pluginsHandler.js
+++ b/lib/pluginsHandler.js
@@ -7,6 +7,8 @@ const init = (service, commands, client) => {
     const sendData = service => client.sendEvent(service, eventData)
     commands.service.getFiltered({
       type: 'plugin'
+    }, {
+      allFields: true
     }).then(services => {
       services.map(sendData)
     })

--- a/lib/pluginsHandler.js
+++ b/lib/pluginsHandler.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const events = require('./events')
+
+const init = (service, commands, client) => {
+  events.emitter.on(events.PLUGIN, eventData => {
+    const sendData = service => client.sendEvent(service, eventData)
+    commands.service.getFiltered({
+      type: 'plugin'
+    }).then(services => {
+      services.map(sendData)
+    })
+  })
+}
+
+module.exports = {
+  init
+}

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -64,7 +64,10 @@ const templates = {
   serviceNotAvailable: 'Service not available',
 
   logAbilityRequired: 'Ability is required',
-  logTypeRequired: 'Type is required'
+  logTypeRequired: 'Type is required',
+
+  sendingEvent: 'Sending "{{entity}}:{{operation}}" event of entity "{{_id}}" to plugin "{{_service}}"',
+  errorSendingEvent: 'Error sending "{{operation}}" "{{entity}}" event to plugin "{{_service}}".'
 }
 
 module.exports = domapic.utils.templates.compile(templates)

--- a/lib/uris.js
+++ b/lib/uris.js
@@ -6,6 +6,7 @@ const { kebabCase } = require('lodash')
 const ABILITIES = 'abilities'
 const STATE_HANDLER_PATH = 'state'
 const ACTION_HANDLER_PATH = 'action'
+const EVENTS = 'events'
 
 const normalizeName = name => kebabCase(name)
 
@@ -16,8 +17,10 @@ const resolveUri = function () {
 // Services
 const abilityStateHandler = name => resolveUri(ABILITIES, normalizeName(name), STATE_HANDLER_PATH)
 const abilityActionHandler = name => resolveUri(ABILITIES, normalizeName(name), ACTION_HANDLER_PATH)
+const serviceEventHandler = () => EVENTS
 
 module.exports = {
   abilityStateHandler,
-  abilityActionHandler
+  abilityActionHandler,
+  serviceEventHandler
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,7 @@ const ValidateUniqueModel = (models, ref, field, errorMessage) => function (valu
   finder[field] = value
 
   if (this && this.model && this._conditions && !this.isNew) {
-    conditions.push({[field]: new RegExp('^' + value + '$', 'i')})
+    conditions.push({ [field]: new RegExp('^' + value + '$', 'i') })
 
     _.each(this._conditions, (value, key) => {
       conditions.push({ [key]: { $ne: value } })

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "domapic-controller",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domapic-controller",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "description": "Controller for Domapic systems",
   "main": "server.js",
   "keywords": [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=domapic
 sonar.projectKey=domapic-controller
-sonar.projectVersion=1.0.0-alpha.8
+sonar.projectVersion=1.0.0-alpha.9
 
 sonar.sources=.
 sonar.exclusions=node_modules/**

--- a/test/functional/specs/abilities-api.specs.js
+++ b/test/functional/specs/abilities-api.specs.js
@@ -5,6 +5,8 @@ const utils = require('./utils')
 
 test.describe('abilities api', function () {
   let authenticator = utils.Authenticator()
+  let pluginId
+  let entityId
 
   const addService = function (serviceData) {
     return utils.request('/services', {
@@ -114,7 +116,12 @@ test.describe('abilities api', function () {
   }
 
   test.before(() => {
-    return utils.doLogin(authenticator)
+    return utils.addPlugin()
+      .then(id => {
+        pluginId = id
+      }).then(() => {
+        return utils.doLogin(authenticator)
+      })
   })
 
   test.describe('add ability', () => {
@@ -213,6 +220,7 @@ test.describe('abilities api', function () {
             return getAbility(abilityId)
               .then((getResponse) => {
                 const ability = getResponse.body
+                entityId = ability._id
                 return Promise.all([
                   test.expect(ability._id).to.equal(abilityId),
                   test.expect(ability.description).to.equal(fooAbility.description),
@@ -228,6 +236,10 @@ test.describe('abilities api', function () {
                 ])
               })
           })
+        })
+
+        test.it('should have sent ability creation event to registered plugins', () => {
+          return utils.expectEvent('ability:create', entityId, pluginId)
         })
       })
     })
@@ -319,6 +331,10 @@ test.describe('abilities api', function () {
               })
           })
       })
+
+      test.it('should have sent ability update event to registered plugins', () => {
+        return utils.expectEvent('ability:update', moduleUserAbility._id, pluginId)
+      })
     })
   })
 
@@ -385,6 +401,10 @@ test.describe('abilities api', function () {
                 ])
               })
           })
+      })
+
+      test.it('should have sent ability delete event to registered plugins', () => {
+        return utils.expectEvent('ability:delete', moduleUserAbility._id, pluginId)
       })
     })
   })

--- a/test/functional/specs/abilities-api.specs.js
+++ b/test/functional/specs/abilities-api.specs.js
@@ -239,7 +239,7 @@ test.describe('abilities api', function () {
         })
 
         test.it('should have sent ability creation event to registered plugins', () => {
-          return utils.expectEvent('ability:create', entityId, pluginId)
+          return utils.expectEvent('ability:created', entityId, pluginId)
         })
       })
     })
@@ -333,7 +333,7 @@ test.describe('abilities api', function () {
       })
 
       test.it('should have sent ability update event to registered plugins', () => {
-        return utils.expectEvent('ability:update', moduleUserAbility._id, pluginId)
+        return utils.expectEvent('ability:updated', moduleUserAbility._id, pluginId)
       })
     })
   })
@@ -404,7 +404,7 @@ test.describe('abilities api', function () {
       })
 
       test.it('should have sent ability delete event to registered plugins', () => {
-        return utils.expectEvent('ability:delete', moduleUserAbility._id, pluginId)
+        return utils.expectEvent('ability:deleted', moduleUserAbility._id, pluginId)
       })
     })
   })

--- a/test/functional/specs/services-api.specs.js
+++ b/test/functional/specs/services-api.specs.js
@@ -5,6 +5,8 @@ const utils = require('./utils')
 
 test.describe('services api', function () {
   let authenticator = utils.Authenticator()
+  let pluginId
+  let entityId
 
   const getServices = function (filters) {
     return utils.request('/services', {
@@ -112,7 +114,11 @@ test.describe('services api', function () {
   }
 
   test.before(() => {
-    return utils.doLogin(authenticator)
+    return utils.addPlugin()
+      .then(id => {
+        pluginId = id
+      })
+      .then(() => utils.doLogin(authenticator))
   })
 
   test.describe('add service', () => {
@@ -190,6 +196,7 @@ test.describe('services api', function () {
       test.it('should add service to database if all provided data pass validation', () => {
         return addService(fooService).then((addResponse) => {
           const serviceId = addResponse.headers.location.split('/').pop()
+          entityId = serviceId
           return getService(serviceId)
             .then((getResponse) => {
               const service = getResponse.body
@@ -206,6 +213,10 @@ test.describe('services api', function () {
               ])
             })
         })
+      })
+
+      test.it('should have sent service creation event to registered plugins', () => {
+        return utils.expectEvent('service:create', entityId, pluginId)
       })
 
       test.it('should return a bad data error if one user tries to add more than one service', () => {
@@ -228,6 +239,46 @@ test.describe('services api', function () {
             })
           })
       })
+    })
+  })
+
+  test.describe('get services', () => {
+    test.it('should return all services', () => {
+      return getServices()
+        .then(getResponse => {
+          return Promise.all([
+            test.expect(getResponse.statusCode).to.equal(200),
+            test.expect(getResponse.body.length).to.equal(2)
+          ])
+        })
+    })
+
+    test.it('should return plugin services when filtering by plugin type', () => {
+      return getServices({
+        type: 'plugin'
+      })
+        .then(getResponse => {
+          const service = getResponse.body.find(service => service.type !== 'plugin')
+          return Promise.all([
+            test.expect(getResponse.statusCode).to.equal(200),
+            test.expect(service).to.be.undefined(),
+            test.expect(getResponse.body.length).to.equal(1)
+          ])
+        })
+    })
+
+    test.it('should return module services when filtering by module type', () => {
+      return getServices({
+        type: 'module'
+      })
+        .then(getResponse => {
+          const service = getResponse.body.find(service => service.type !== 'module')
+          return Promise.all([
+            test.expect(getResponse.statusCode).to.equal(200),
+            test.expect(service).to.be.undefined(),
+            test.expect(getResponse.body.length).to.equal(1)
+          ])
+        })
     })
   })
 
@@ -366,6 +417,10 @@ test.describe('services api', function () {
                 ])
               })
           })
+      })
+
+      test.it('should have sent service update event to registered plugins', () => {
+        return utils.expectEvent('service:update', moduleUserService._id, pluginId)
       })
 
       test.it('should update all provided service data even when url is same than before', () => {

--- a/test/functional/specs/services-api.specs.js
+++ b/test/functional/specs/services-api.specs.js
@@ -216,7 +216,7 @@ test.describe('services api', function () {
       })
 
       test.it('should have sent service creation event to registered plugins', () => {
-        return utils.expectEvent('service:create', entityId, pluginId)
+        return utils.expectEvent('service:created', entityId, pluginId)
       })
 
       test.it('should return a bad data error if one user tries to add more than one service', () => {
@@ -420,7 +420,7 @@ test.describe('services api', function () {
       })
 
       test.it('should have sent service update event to registered plugins', () => {
-        return utils.expectEvent('service:update', moduleUserService._id, pluginId)
+        return utils.expectEvent('service:updated', moduleUserService._id, pluginId)
       })
 
       test.it('should update all provided service data even when url is same than before', () => {

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -208,7 +208,7 @@ test.describe('users api', function () {
       })
 
       test.it('should have sent user creation event to registered plugins', () => {
-        return utils.expectEvent('user:create', entityId, pluginId)
+        return utils.expectEvent('user:created', entityId, pluginId)
       })
 
       test.it('should return a bad data error if an already existant email is provided', () => {

--- a/test/functional/specs/utils.js
+++ b/test/functional/specs/utils.js
@@ -3,6 +3,7 @@
 const path = require('path')
 const fs = require('fs')
 const querystring = require('querystring')
+const test = require('narval')
 const testUtils = require('narval/utils')
 
 const { omitBy, isUndefined } = require('lodash')
@@ -168,6 +169,42 @@ const ensureUserAndDoLogin = (authenticator, userData) => {
 
 const readLogs = () => testUtils.logs.combined('controller')
 
+const addPlugin = () => {
+  const authenticator = Authenticator()
+  return ensureUserAndDoLogin(authenticator, {
+    name: 'foo-events-plugin',
+    role: 'plugin',
+    email: 'events-plugin@foo.com',
+    password: 'foo'
+  }).then(() => {
+    return request('/services', {
+      method: 'POST',
+      body: {
+        processId: 'foo-plugin-service-id',
+        description: 'foo-plugin-description',
+        package: 'foo-plugin-package',
+        version: '1.0.0',
+        apiKey: 'dasdasdqe342312reww4r4234wgsdfsf',
+        url: 'https://192.132.112.1:3500',
+        type: 'plugin'
+      },
+      ...authenticator.credentials()
+    }).then(response => {
+      return Promise.resolve(response.headers.location.split('/').pop())
+    })
+  })
+}
+
+const expectEvent = (event, entityId, pluginId) => {
+  return waitOnestimatedStartTime(200)
+    .then(() => {
+      return readLogs()
+        .then(logs => {
+          return test.expect(logs).to.contain(`Sending "${event}" event of entity "${entityId}" to plugin "${pluginId}"`)
+        })
+    })
+}
+
 module.exports = {
   superAdmin,
   waitOnestimatedStartTime,
@@ -179,5 +216,7 @@ module.exports = {
   createUser,
   ensureUser,
   ensureUserAndDoLogin,
-  readLogs
+  readLogs,
+  addPlugin,
+  expectEvent
 }

--- a/test/unit/Base.mocks.js
+++ b/test/unit/Base.mocks.js
@@ -24,7 +24,8 @@ const Mock = function () {
     tracer: {
       info: sandbox.stub().usingPromise().resolves(),
       debug: sandbox.stub().usingPromise().resolves(),
-      error: sandbox.stub().usingPromise().resolves()
+      error: sandbox.stub().usingPromise().resolves(),
+      warn: sandbox.stub().usingPromise().resolves()
     },
     errors: {
       BadData: sandbox.stub().returns(new Error()),

--- a/test/unit/lib/Events.mocks.js
+++ b/test/unit/lib/Events.mocks.js
@@ -1,0 +1,67 @@
+
+const test = require('narval')
+
+const events = require('../../../lib/events')
+
+const CallBackRunnerFake = function (options = {}) {
+  let cbs = []
+  const fake = function (eventName, cb) {
+    if (options.runOnRegister) {
+      cb(options.returns)
+    }
+    cbs.push(cb)
+  }
+
+  const returns = function (code) {
+    options.returns = code
+  }
+
+  const runOnRegister = function (run) {
+    options.runOnRegister = run
+  }
+
+  const run = function (data) {
+    cbs.map(cb => cb(data))
+  }
+
+  return {
+    fake: fake,
+    returns: returns,
+    runOnRegister: runOnRegister,
+    run: run
+  }
+}
+
+const Mock = function () {
+  const sandbox = test.sinon.createSandbox()
+  const originalEmitter = events.emitter
+
+  const emmiterOnFake = new CallBackRunnerFake({
+    runOnRegister: true
+  })
+
+  const emitterStubs = {
+    on: sandbox.stub().callsFake(emmiterOnFake.fake)
+  }
+
+  emitterStubs.on.returns = emmiterOnFake.returns
+
+  events.emitter = emitterStubs
+
+  const stubs = {
+    emitter: emitterStubs,
+    plugin: sandbox.stub(events, 'plugin')
+  }
+
+  const restore = function () {
+    sandbox.restore()
+    events.emitter = originalEmitter
+  }
+
+  return {
+    stubs: stubs,
+    restore: restore
+  }
+}
+
+module.exports = Mock

--- a/test/unit/lib/PluginsHandler.mocks.js
+++ b/test/unit/lib/PluginsHandler.mocks.js
@@ -1,12 +1,12 @@
 const test = require('narval')
 
+const pluginsHandler = require('../../../lib/pluginsHandler')
+
 const Mock = function () {
   const sandbox = test.sinon.createSandbox()
 
   const stubs = {
-    sendAction: sandbox.stub().usingPromise().resolves(),
-    getState: sandbox.stub().usingPromise().resolves(),
-    sendEvent: sandbox.stub().usingPromise().resolves()
+    init: sandbox.stub(pluginsHandler, 'init').resolves()
   }
 
   const restore = function () {

--- a/test/unit/lib/api/abilities.specs.js
+++ b/test/unit/lib/api/abilities.specs.js
@@ -11,16 +11,19 @@ test.describe('abilities api', () => {
     let operations
     let commandsMocks
     let baseMocks
+    let eventsMocks
 
     test.beforeEach(() => {
       baseMocks = new mocks.Base()
       commandsMocks = new mocks.Commands()
+      eventsMocks = new mocks.Events()
       operations = abilities.Operations(baseMocks.stubs.service, commandsMocks.stubs)
     })
 
     test.afterEach(() => {
       baseMocks.restore()
       commandsMocks.restore()
+      eventsMocks.restore()
     })
 
     test.describe('getAbilities handler', () => {
@@ -138,6 +141,13 @@ test.describe('abilities api', () => {
           })
       })
 
+      test.it('should emit a plugin event', () => {
+        return operations.addAbility.handler({}, fooBody, response, fooUserData)
+          .then(() => {
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'create', fooAbility)
+          })
+      })
+
       test.it('should resolve the promise with no value', () => {
         return operations.addAbility.handler({}, fooBody, response, fooUserData)
           .then((result) => {
@@ -240,6 +250,17 @@ test.describe('abilities api', () => {
           })
       })
 
+      test.it('should emit a plugin event', () => {
+        return operations.updateAbility.handler({
+          path: {
+            id: fooId
+          }
+        }, fooBody, response)
+          .then(() => {
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'update', fooAbility)
+          })
+      })
+
       test.it('should resolve the promise with no value', () => {
         return operations.updateAbility.handler({
           path: {
@@ -330,6 +351,19 @@ test.describe('abilities api', () => {
           })
       })
 
+      test.it('should emit a plugin event', () => {
+        return operations.deleteAbility.handler({
+          path: {
+            id: fooId
+          }
+        }, {}, response)
+          .then(() => {
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'delete', {
+              _id: fooId
+            })
+          })
+      })
+
       test.it('should resolve the promise with no value', () => {
         return operations.deleteAbility.handler({
           path: {
@@ -393,6 +427,20 @@ test.describe('abilities api', () => {
         }, fooActionData, response)
           .then(() => {
             return test.expect(response.header).to.have.been.calledWith('location', '/api/abilities/foo-ability-id/state')
+          })
+      })
+
+      test.it('should emit a plugin event', () => {
+        return operations.abilityAction.handler({
+          path: {
+            id: fooId
+          }
+        }, fooActionData, response)
+          .then(() => {
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'action', {
+              _id: fooId,
+              ...fooActionData
+            })
           })
       })
 
@@ -508,6 +556,20 @@ test.describe('abilities api', () => {
         }, fooActionData, response)
           .then(() => {
             return test.expect(response.header).to.have.been.calledWith('location', '/api/abilities/foo-ability-id/state')
+          })
+      })
+
+      test.it('should emit a plugin event', () => {
+        return operations.abilityEvent.handler({
+          path: {
+            id: fooId
+          }
+        }, fooActionData, response)
+          .then(() => {
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'event', {
+              _id: fooId,
+              ...fooActionData
+            })
           })
       })
 

--- a/test/unit/lib/api/abilities.specs.js
+++ b/test/unit/lib/api/abilities.specs.js
@@ -144,7 +144,7 @@ test.describe('abilities api', () => {
       test.it('should emit a plugin event', () => {
         return operations.addAbility.handler({}, fooBody, response, fooUserData)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'create', fooAbility)
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'created', fooAbility)
           })
       })
 
@@ -257,7 +257,7 @@ test.describe('abilities api', () => {
           }
         }, fooBody, response)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'update', fooAbility)
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'updated', fooAbility)
           })
       })
 
@@ -358,7 +358,7 @@ test.describe('abilities api', () => {
           }
         }, {}, response)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'delete', {
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('ability', 'deleted', {
               _id: fooId
             })
           })

--- a/test/unit/lib/api/services.specs.js
+++ b/test/unit/lib/api/services.specs.js
@@ -173,7 +173,7 @@ test.describe('services api', () => {
       test.it('should emit a plugin event', () => {
         return operations.addService.handler({}, fooBody, response, fooUserData)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('service', 'create', fooService)
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('service', 'created', fooService)
           })
       })
 
@@ -285,7 +285,7 @@ test.describe('services api', () => {
           }
         }, fooBody, response)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('service', 'update', fooService)
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('service', 'updated', fooService)
           })
       })
 

--- a/test/unit/lib/api/services.specs.js
+++ b/test/unit/lib/api/services.specs.js
@@ -11,16 +11,19 @@ test.describe('services api', () => {
     let operations
     let commandsMocks
     let baseMocks
+    let eventsMocks
 
     test.beforeEach(() => {
       baseMocks = new mocks.Base()
       commandsMocks = new mocks.Commands()
       operations = services.Operations(baseMocks.stubs.service, commandsMocks.stubs)
+      eventsMocks = new mocks.Events()
     })
 
     test.afterEach(() => {
       baseMocks.restore()
       commandsMocks.restore()
+      eventsMocks.restore()
     })
 
     test.describe('getServices handler', () => {
@@ -28,11 +31,27 @@ test.describe('services api', () => {
         const fooResult = 'foo result'
         commandsMocks.stubs.service.getFiltered.resolves(fooResult)
 
-        return operations.getServices.handler()
+        return operations.getServices.handler({query: {}})
           .then((result) => {
             return Promise.all([
               test.expect(result).to.equal(fooResult),
               test.expect(commandsMocks.stubs.service.getFiltered).to.have.been.calledWith()
+            ])
+          })
+      })
+
+      test.it('should pass received query data to get services command', () => {
+        const fooResult = 'foo result'
+        const fooQuery = {
+          type: 'foo-type'
+        }
+        commandsMocks.stubs.service.getFiltered.resolves(fooResult)
+
+        return operations.getServices.handler({query: fooQuery})
+          .then((result) => {
+            return Promise.all([
+              test.expect(result).to.equal(fooResult),
+              test.expect(commandsMocks.stubs.service.getFiltered).to.have.been.calledWith(fooQuery)
             ])
           })
       })
@@ -151,6 +170,13 @@ test.describe('services api', () => {
           })
       })
 
+      test.it('should emit a plugin event', () => {
+        return operations.addService.handler({}, fooBody, response, fooUserData)
+          .then(() => {
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('service', 'create', fooService)
+          })
+      })
+
       test.it('should resolve the promise with no value', () => {
         return operations.addService.handler({}, fooBody, response)
           .then((result) => {
@@ -249,6 +275,17 @@ test.describe('services api', () => {
         }, fooBody, response)
           .then(() => {
             return test.expect(response.header).to.have.been.calledWith('location', '/api/services/foo-service-id')
+          })
+      })
+
+      test.it('should emit a plugin event', () => {
+        return operations.updateService.handler({
+          path: {
+            id: fooId
+          }
+        }, fooBody, response)
+          .then(() => {
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('service', 'update', fooService)
           })
       })
 

--- a/test/unit/lib/api/users.specs.js
+++ b/test/unit/lib/api/users.specs.js
@@ -11,16 +11,19 @@ test.describe('users api', () => {
     let operations
     let commandsMocks
     let baseMocks
+    let eventsMocks
 
     test.beforeEach(() => {
       baseMocks = new mocks.Base()
       commandsMocks = new mocks.Commands()
       operations = users.Operations(baseMocks.stubs.service, commandsMocks.stubs)
+      eventsMocks = new mocks.Events()
     })
 
     test.afterEach(() => {
       baseMocks.restore()
       commandsMocks.restore()
+      eventsMocks.restore()
     })
 
     test.describe('getUsers auth', () => {
@@ -46,6 +49,16 @@ test.describe('users api', () => {
         }, {
           query: {
             role: 'plugin'
+          }
+        }, {})).to.be.true()
+      })
+
+      test.it('should return true if provided user has "plugin" role and received role in query is "operator"', () => {
+        test.expect(operations.getUsers.auth({
+          role: 'plugin'
+        }, {
+          query: {
+            role: 'operator'
           }
         }, {})).to.be.true()
       })
@@ -122,33 +135,129 @@ test.describe('users api', () => {
     })
 
     test.describe('getUser auth', () => {
-      test.it('should return true if provided user has "admin" role', () => {
-        test.expect(operations.getUser.auth({
-          role: 'admin'
-        }, {}, {})).to.be.true()
+      test.beforeEach(() => {
+        commandsMocks.stubs.user.getById.resolves({
+          role: 'operator'
+        })
       })
 
-      test.it('should return true if provided user id is same than logged user', () => {
-        test.expect(operations.getUser.auth({
+      test.it('should resolve if provided user has "admin" role', () => {
+        return operations.getUser.auth({
+          role: 'admin'
+        }, {
+          path: {
+            id: 'foo-id'
+          }
+        }, {}).then(() => {
+          return test.expect(true).to.be.true()
+        })
+      })
+
+      test.it('should resolve if provided user has "service-registerer" role and requested user has "module" role', () => {
+        commandsMocks.stubs.user.getById.resolves({
+          role: 'module'
+        })
+        return operations.getUser.auth({
+          role: 'service-registerer'
+        }, {
+          path: {
+            id: 'foo-id'
+          }
+        }, {}).then(() => {
+          return test.expect(true).to.be.true()
+        })
+      })
+
+      test.it('should return true if provided user has "service-registerer" role and requested user has "plugin" role', () => {
+        commandsMocks.stubs.user.getById.resolves({
+          role: 'plugin'
+        })
+        return operations.getUser.auth({
+          role: 'service-registerer'
+        }, {
+          path: {
+            id: 'foo-id'
+          }
+        }, {}).then(() => {
+          return test.expect(true).to.be.true()
+        })
+      })
+
+      test.it('should return true if provided user has "plugin" role and requested user is "operator"', () => {
+        commandsMocks.stubs.user.getById.resolves({
+          role: 'operator'
+        })
+        return operations.getUser.auth({
+          role: 'plugin'
+        }, {
+          path: {
+            id: 'foo-id'
+          }
+        }, {}).then(() => {
+          return test.expect(true).to.be.true()
+        })
+      })
+
+      test.it('should resolve if provided user id is same than logged user', () => {
+        return operations.getUser.auth({
           role: 'plugin',
           _id: 'foo-id'
         }, {
           path: {
             id: 'foo-id'
           }
-        }, {})).to.be.true()
+        }, {}).then(() => {
+          return test.expect(true).to.be.true()
+        })
       })
 
-      test.it('should return false if provided user id is different than logged user', () => {
-        test.expect(operations.getUser.auth({
+      test.it('should reject the promise if provided user id is different than logged user', () => {
+        return operations.getUser.auth({
           role: 'module',
           _id: 'foo-id'
         }, {
           path: {
             id: 'foo-different-id'
           }
-        }, {})).to.be.false()
+        }, {}).then(() => {
+          return test.assert.fail()
+        }, error => {
+          return test.expect(error).to.be.an.instanceOf(Error)
+        })
       })
+
+      const testRole = function (userRole, requestedRole) {
+        test.it(`should reject if user has "${userRole}" role and requested user has "${requestedRole}" role`, () => {
+          commandsMocks.stubs.user.getById.resolves({
+            role: requestedRole
+          })
+          return operations.getUser.auth({
+            role: userRole
+          }, {
+            path: {
+              id: 'foo-id'
+            }
+          }, {}).then(() => {
+            return test.assert.fail()
+          }, error => {
+            return test.expect(error).to.be.an.instanceOf(Error)
+          })
+        })
+      }
+      testRole('plugin', 'admin')
+      testRole('plugin', 'module')
+      testRole('plugin', 'plugin')
+      testRole('plugin', 'service-registerer')
+      testRole('operator', 'admin')
+      testRole('operator', 'module')
+      testRole('operator', 'plugin')
+      testRole('operator', 'service-registerer')
+      testRole('service-registerer', 'admin')
+      testRole('service-registerer', 'operator')
+      testRole('module', 'admin')
+      testRole('module', 'operator')
+      testRole('module', 'module')
+      testRole('module', 'plugin')
     })
 
     test.describe('getUser handler', () => {
@@ -211,31 +320,51 @@ test.describe('users api', () => {
         })).to.be.true()
       })
 
-      const testServiceRegistererRole = function (role) {
-        test.it(`should return false if provided user has "service-registerer" role and body user has "${role}" role`, () => {
+      test.it('should return true if provided user has "plugin" role and received role in query is "operator"', () => {
+        test.expect(operations.addUser.auth({
+          role: 'plugin'
+        }, {}, {
+          role: 'operator'
+        })).to.be.true()
+      })
+
+      const testRole = function (userRole, role) {
+        test.it(`should reject if user has "${userRole}" role and body user has "${role}" role`, () => {
           test.expect(operations.addUser.auth({
-            role: 'service-registerer'
+            role: userRole
           }, {}, {
             role
           })).to.be.false()
         })
       }
 
-      testServiceRegistererRole('operator')
-      testServiceRegistererRole('admin')
-      testServiceRegistererRole('service-registerer')
+      testRole('plugin', 'admin')
+      testRole('plugin', 'module')
+      testRole('plugin', 'plugin')
+      testRole('plugin', 'service-registerer')
+      testRole('operator', 'admin')
+      testRole('operator', 'module')
+      testRole('operator', 'plugin')
+      testRole('operator', 'service-registerer')
+      testRole('service-registerer', 'admin')
+      testRole('service-registerer', 'operator')
+      testRole('module', 'admin')
+      testRole('module', 'operator')
+      testRole('module', 'module')
+      testRole('module', 'plugin')
 
-      const testRole = function (role) {
+      const testEmptyRole = function (role) {
         test.it(`should return false if provided user has "${role}" role`, () => {
           test.expect(operations.addUser.auth({
             role
           }, {}, {})).to.be.false()
         })
       }
-      testRole('module')
-      testRole('operator')
-      testRole('plugin')
-      testRole('service-registerer')
+
+      testEmptyRole('module')
+      testEmptyRole('operator')
+      testEmptyRole('plugin')
+      testEmptyRole('service-registerer')
     })
 
     test.describe('addUser handler', () => {
@@ -280,6 +409,13 @@ test.describe('users api', () => {
         return operations.addUser.handler({}, fooBody, response)
           .then(() => {
             return test.expect(response.header).to.have.been.calledWith('location', '/api/users/foo-id')
+          })
+      })
+
+      test.it('should emit a plugin event', () => {
+        return operations.addUser.handler({}, fooBody, response)
+          .then(() => {
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('user', 'create', fooUser)
           })
       })
 

--- a/test/unit/lib/api/users.specs.js
+++ b/test/unit/lib/api/users.specs.js
@@ -415,7 +415,7 @@ test.describe('users api', () => {
       test.it('should emit a plugin event', () => {
         return operations.addUser.handler({}, fooBody, response)
           .then(() => {
-            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('user', 'create', fooUser)
+            return test.expect(eventsMocks.stubs.plugin).to.have.been.calledWith('user', 'created', fooUser)
           })
       })
 

--- a/test/unit/lib/commands/service.specs.js
+++ b/test/unit/lib/commands/service.specs.js
@@ -103,6 +103,19 @@ test.describe('service commands', () => {
             ])
           })
       })
+
+      test.it('should not filter fields if allFields option is received', () => {
+        modelsMocks.stubs.Service.find.resolves(fooServices)
+        return commands.getFiltered({}, {
+          allFields: true
+        })
+          .then((result) => {
+            return Promise.all([
+              test.expect(result).to.equal(fooServices),
+              test.expect(modelsMocks.stubs.Service.find).to.have.been.calledWith({}, undefined)
+            ])
+          })
+      })
     })
 
     test.describe('get method', () => {

--- a/test/unit/lib/controller.specs.js
+++ b/test/unit/lib/controller.specs.js
@@ -12,17 +12,20 @@ test.describe('controller', () => {
     }
     let baseMocks
     let indexMocks
+    let pluginHandlerMocks
 
     test.beforeEach(() => {
       indexMocks = new mocks.Index()
       indexMocks.stubs.security.methods.resolves(fooSecurityMethods)
       baseMocks = new mocks.Base()
+      pluginHandlerMocks = new mocks.PluginsHandler()
       return controller.start()
     })
 
     test.afterEach(() => {
       indexMocks.restore()
       baseMocks.restore()
+      pluginHandlerMocks.restore()
     })
 
     test.it('should have created a new Service instance', () => {
@@ -51,6 +54,10 @@ test.describe('controller', () => {
 
     test.it('should have created a new Api instance', () => {
       test.expect(indexMocks.stubs.Api).to.have.been.calledWith(baseMocks.stubs.service, indexMocks.stubs.commands)
+    })
+
+    test.it('should have inited plugins handler', () => {
+      test.expect(pluginHandlerMocks.stubs.init).to.have.been.called()
     })
 
     test.it('should have called to connect to database', () => {

--- a/test/unit/lib/events.specs.js
+++ b/test/unit/lib/events.specs.js
@@ -1,0 +1,33 @@
+
+const test = require('narval')
+
+const events = require('../../../lib/events')
+
+test.describe('events', () => {
+  let sandbox
+
+  test.beforeEach(() => {
+    sandbox = test.sinon.createSandbox()
+    sandbox.stub(events.emitter, 'emit')
+  })
+
+  test.afterEach(() => {
+    sandbox.restore()
+  })
+
+  test.describe('plugin method', () => {
+    test.it('should emit a plugin event, passing entity, operation and data', () => {
+      const fooEntity = 'foo-entity'
+      const fooOperation = 'foo-operation'
+      const fooData = {
+        foo: 'foo'
+      }
+      events.plugin(fooEntity, fooOperation, fooData)
+      return test.expect(events.emitter.emit).to.have.been.calledWith('plugin', {
+        entity: fooEntity,
+        operation: fooOperation,
+        data: fooData
+      })
+    })
+  })
+})

--- a/test/unit/lib/pluginsHandler.specs.js
+++ b/test/unit/lib/pluginsHandler.specs.js
@@ -1,0 +1,66 @@
+
+const test = require('narval')
+
+const pluginsHandler = require('../../../lib/pluginsHandler')
+const mocks = require('../mocks')
+
+const waitForFinish = () => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve()
+    }, 200)
+  })
+}
+
+test.describe('pluginsHandler', () => {
+  let commandsMocks
+  let baseMocks
+  let eventsMocks
+  let clientMocks
+
+  test.beforeEach(() => {
+    baseMocks = new mocks.Base()
+    commandsMocks = new mocks.Commands()
+    eventsMocks = new mocks.Events()
+    clientMocks = new mocks.Client()
+  })
+
+  test.afterEach(() => {
+    baseMocks.restore()
+    commandsMocks.restore()
+    eventsMocks.restore()
+    clientMocks.restore()
+  })
+
+  test.describe('init method', () => {
+    test.it('should listen to plugin events, and send them to al registered plugins', () => {
+      const fooEventData = {
+        entity: 'foo-entity',
+        operation: 'foo-operation',
+        data: {
+          _id: 'foo-id',
+          foo: 'foo-data'
+        }
+      }
+      const fooServices = [
+        'foo-service-1',
+        'foo-service-2'
+      ]
+      commandsMocks.stubs.service.getFiltered.resolves(fooServices)
+      eventsMocks.stubs.emitter.on.returns(fooEventData)
+      pluginsHandler.init(baseMocks.stubs.service, commandsMocks.stubs, clientMocks.stubs)
+      return waitForFinish()
+        .then(() => {
+          return Promise.all([
+            test.expect(eventsMocks.stubs.emitter.on).to.have.been.called(),
+            test.expect(commandsMocks.stubs.service.getFiltered).to.have.been.calledWith({
+              type: 'plugin'
+            }),
+            test.expect(clientMocks.stubs.sendEvent).to.have.been.calledTwice(),
+            test.expect(clientMocks.stubs.sendEvent.getCall(0).args[0]).to.equal(fooServices[0]),
+            test.expect(clientMocks.stubs.sendEvent.getCall(1).args[0]).to.equal(fooServices[1])
+          ])
+        })
+    })
+  })
+})

--- a/test/unit/lib/uri.specs.js
+++ b/test/unit/lib/uri.specs.js
@@ -15,4 +15,10 @@ test.describe('uri utils', () => {
       test.expect(uris.abilityStateHandler('foo_name')).to.equal('abilities/foo-name/state')
     })
   })
+
+  test.describe('serviceEventHandler method', () => {
+    test.it('should return the event uri', () => {
+      test.expect(uris.serviceEventHandler()).to.equal('events')
+    })
+  })
 })

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -2,8 +2,10 @@
 const Mongoose = require('./Mongoose.mocks')
 const Base = require('./Base.mocks')
 const Client = require('./lib/Client.mocks')
+const Events = require('./lib/Events.mocks')
 const Security = require('./lib/Security.mocks')
 const Utils = require('./lib/Utils.mocks')
+const PluginsHandler = require('./lib/PluginsHandler.mocks')
 
 const Controller = require('./lib/Controller.mocks')
 const Database = require('./lib/Database.mocks')
@@ -57,6 +59,8 @@ module.exports = {
   },
   Base,
   Client,
+  Events,
+  PluginsHandler,
   Commands,
   Controller,
   Database,


### PR DESCRIPTION
### Added
- Send entity operations events to all registered plugins
- Add type filter to get services api
### Changed
- Allow plugin users to create and get operator users
### Fixed
- Fix role-based permissions in get user api