### PR TITLE
Plugin admin permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ addons:
       name: "$TRAVIS_CURRENT_BRANCH"
 
 script:
-  - npm test
+  - npm test -- --suite=users --logLevel=trace
   - npm run coveralls
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sonar-scanner; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ addons:
       name: "$TRAVIS_CURRENT_BRANCH"
 
 script:
-  - npm test -- --suite=users --logLevel=trace
+  - npm test
   - npm run coveralls
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sonar-scanner; fi'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [1.0.0-beta.3] - 2019-05-01
+### Added
+- Add user adminPermissions property, intended for grant admin permissions to plugin users when login using apiKey
+- Avoid any other user than admin updating adminPermissions property
+
 ## [1.0.0-beta.2] - 2019-03-02
 ### Added
 - Add web ui

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -55,10 +55,12 @@ const Operations = (service, commands) => {
             if (
               // Only operators and admin users can be modified, or plugins in case adminPermissions is the uniq property being modified
               ([roles.ADMIN, roles.OPERATOR].includes(user.role) || (user.role === roles.PLUGIN && Object.keys(body).length === 1 && !isUndefined(body.adminPermissions))) &&
-              // Role can be only modified by administrators
-              (userData.role === roles.ADMIN || (params.path.id === userData._id && !body.role)) &&
+              // Role and adminPermissions can be only modified by administrators
+              (userData.role === roles.ADMIN || (params.path.id === userData._id && !body.role && !body.adminPermissions)) &&
               // Role can be modified only to operator or admin roles
-              (!body.role || [roles.ADMIN, roles.OPERATOR].includes(body.role))
+              (!body.role || [roles.ADMIN, roles.OPERATOR].includes(body.role)) &&
+              // adminPermissions can be modified only to plugin roles
+              (!body.adminPermissions || user.role === roles.PLUGIN)
             ) {
               return Promise.resolve()
             }

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -52,6 +52,11 @@ const Operations = (service, commands) => {
       auth: (userData, params, body) => {
         return commands.user.getById(params.path.id)
           .then(user => {
+            console.log("---------------------- UPDATING USER")
+            console.log("userData-----------")
+            console.log(userData)
+            console.log("body-----------")
+            console.log(body)
             if (
               // Only operators and admin users can be modified, or plugins in case adminPermissions is the uniq property being modified
               ([roles.ADMIN, roles.OPERATOR].includes(user.role) || (user.role === roles.PLUGIN && Object.keys(body).length === 1 && !isUndefined(body.adminPermissions))) &&

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -52,11 +52,6 @@ const Operations = (service, commands) => {
       auth: (userData, params, body) => {
         return commands.user.getById(params.path.id)
           .then(user => {
-            console.log("---------------------- UPDATING USER")
-            console.log("userData-----------")
-            console.log(userData)
-            console.log("body-----------")
-            console.log(body)
             if (
               // Only operators and admin users can be modified, or plugins in case adminPermissions is the uniq property being modified
               ([roles.ADMIN, roles.OPERATOR].includes(user.role) || (user.role === roles.PLUGIN && Object.keys(body).length === 1 && !isUndefined(body.adminPermissions))) &&

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -53,8 +53,8 @@ const Operations = (service, commands) => {
         return commands.user.getById(params.path.id)
           .then(user => {
             if (
-              // Only operators and admin users can be modified
-              [roles.ADMIN, roles.OPERATOR].includes(user.role) &&
+              // Only operators and admin users can be modified, or plugins in case adminPermissions is the uniq property being modified
+              ([roles.ADMIN, roles.OPERATOR].includes(user.role) || (user.role === roles.PLUGIN && Object.keys(body).length === 1 && !isUndefined(body.adminPermissions))) &&
               // Role can be only modified by administrators
               (userData.role === roles.ADMIN || (params.path.id === userData._id && !body.role)) &&
               // Role can be modified only to operator or admin roles

--- a/lib/api/users.json
+++ b/lib/api/users.json
@@ -35,6 +35,10 @@
           "updatedAt": {
             "description": "Last update date timestamp",
             "type": "string"
+          },
+          "adminPermissions": {
+            "description": "Grant admin permissions to this user",
+            "type": "boolean"
           }
         },
         "additionalProperties": false,
@@ -98,6 +102,10 @@
             "description": "Role assigned to the user",
             "type": "string",
             "enum": ["admin", "operator", "module", "plugin", "service-registerer"]
+          },
+          "adminPermissions": {
+            "description": "Grant admin permissions to this user",
+            "type": "boolean"
           }
         },
         "additionalProperties": false,

--- a/lib/commands/securityToken.js
+++ b/lib/commands/securityToken.js
@@ -15,11 +15,12 @@ const Commands = (service, models, client) => {
     return Promise.resolve(token)
   }
 
-  const add = (userData, type) => {
+  const add = (userData, type, creatorUser) => {
     const token = new models.SecurityToken({
       token: randToken.generate(64),
       _user: userData._id,
-      type
+      type,
+      createdBy: creatorUser && creatorUser._id.toString()
     })
     return token.save()
       .catch(error => utils.transformValidationErrors(error, service))

--- a/lib/commands/user.js
+++ b/lib/commands/user.js
@@ -4,7 +4,7 @@ const templates = require('../templates')
 const utils = require('../utils')
 const { INITIAL_ADMIN_USER, SERVICE_REGISTERER_USER, ANONYMOUS_USER } = require('../security/utils')
 
-const PUBLIC_FIELDS = 'name email role updatedAt createdAt'
+const PUBLIC_FIELDS = 'name email role updatedAt createdAt adminPermissions'
 
 const Commands = (service, models, client) => {
   const ensureUser = user => {

--- a/lib/models/securityToken.js
+++ b/lib/models/securityToken.js
@@ -30,6 +30,9 @@ const Model = service => {
         securityUtils.API_KEY,
         securityUtils.JWT
       ]
+    },
+    createdBy: {
+      type: String
     }
   },
   {

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -52,6 +52,9 @@ const Model = service => {
       type: String,
       required: [true, templates.userRoleRequired()],
       enum: _.map(roles, role => role)
+    },
+    adminPermissions: {
+      type: Boolean
     }
   },
   {

--- a/lib/security/apiKey.js
+++ b/lib/security/apiKey.js
@@ -21,8 +21,8 @@ const Methods = (service, commands) => {
     return Promise.reject(new service.errors.Forbidden())
   }
 
-  const authenticateHandler = (params, body) => commands.user.getById(body.user)
-    .then(user => commands.securityToken.add(user, utils.API_KEY)
+  const authenticateHandler = (params, body, res, userData) => commands.user.getById(body.user)
+    .then(user => commands.securityToken.add(user, utils.API_KEY, userData)
       .then(securityToken => Promise.resolve(securityToken.token))
     )
 

--- a/lib/security/utils.js
+++ b/lib/security/utils.js
@@ -39,7 +39,12 @@ const cleanUserData = userData => ({
 })
 
 const GetUserBySecurityToken = commands => securityToken => commands.securityToken.getUser(securityToken)
-  .then(userData => Promise.resolve(cleanUserData(userData)))
+  .then(userData => {
+    if (userData.adminPermissions) {
+      userData.role = roles.ADMIN
+    }
+    return Promise.resolve(cleanUserData(userData))
+  })
 
 const GetAnonymousUser = commands => () => {
   if (anonymousUserPromise) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "domapic-controller",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1653,9 +1653,9 @@
       }
     },
     "domapic-controller-ui": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/domapic-controller-ui/-/domapic-controller-ui-1.0.0-beta.2.tgz",
-      "integrity": "sha512-gFxvSzO68O+1iE83IQ9I353jjd9+YBqSzFXcXM32r+CKaY62zIqfX7SklMLjM7h9qxkzG1gY2jAr7cmGySNK2w==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/domapic-controller-ui/-/domapic-controller-ui-1.0.0-beta.3.tgz",
+      "integrity": "sha512-bhnEUB2WFKVkx7YWPfEF9o84TrsXOm+y5JhtjHYWR3PE9Iep3QV23COzcUuZp3Tuc4fcFKQxr1KESUrHe7Z9Cg==",
       "requires": {
         "validator": "^10.11.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "domapic-base": "1.0.0-beta.20",
-    "domapic-controller-ui": "1.0.0-beta.2",
+    "domapic-controller-ui": "1.0.0-beta.3",
     "express-mongo-sanitize": "1.3.2",
     "inquirer": "6.2.1",
     "inquirer-autocomplete-prompt": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domapic-controller",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Controller for Domapic systems",
   "main": "server.js",
   "keywords": [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=domapic
 sonar.projectKey=domapic-controller
-sonar.projectVersion=1.0.0-beta.2
+sonar.projectVersion=1.0.0-beta.3
 
 sonar.sources=.
 sonar.exclusions=node_modules/**

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -536,6 +536,14 @@ test.describe('users api', function () {
           ])
         })
       })
+
+      test.it('should be able to update adminPermissions of plugin users', () => {
+        return updateUser(pluginUserId, {
+          adminPermissions: true
+        }).then(response => {
+          return test.expect(response.statusCode).to.equal(204)
+        })
+      })
     })
 
     test.describe('when user is operator', () => {

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -538,21 +538,27 @@ test.describe('users api', function () {
       })
 
       test.it('should be able to update adminPermissions of plugin users', () => {
-        return updateUser(pluginUserId, {
-          adminPermissions: true
-        }).then(response => {
-          return test.expect(response.statusCode).to.equal(204)
+        return getUsers().then(usersResponse => {
+          return Promise.resolve(usersResponse.body.find(userData => userData.name === 'foo-plugin')._id)
+        }).then(pluginId => {
+          return updateUser(pluginId, {
+            adminPermissions: true
+          }).then(response => {
+            return test.expect(response.statusCode).to.equal(204)
+          })
         })
       })
     })
 
     test.describe('when user has role "plugin" with adminPermissions checked', () => {
+      let pluginUserId
       test.before(() => {
         return utils.ensureUserAndDoLogin(authenticator, pluginUser).then(() => {
-          return getUserMe().then(data => {
-            console.log("----------------- userMe")
-            console.log(data)
-            console.log("----------------- pluginUserId")
+          return getUserMe().then(response => {
+            pluginUserId = response.body._id
+            console.log('----------------- userMe')
+            console.log(response.body)
+            console.log('----------------- pluginUserId')
             console.log(pluginUserId)
             return Promise.resolve()
           })

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -8,6 +8,7 @@ test.describe('users api', function () {
   let authenticator = utils.Authenticator()
   let adminUserId
   let pluginId
+  let pluginUserId
   let entityId
   let operatorUserId
 
@@ -471,7 +472,6 @@ test.describe('users api', function () {
 
   test.describe('update user', () => {
     let moduleUserId
-    let pluginUserId
 
     test.before(() => {
       return utils.doLogin(authenticator)

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -546,6 +546,27 @@ test.describe('users api', function () {
       })
     })
 
+    test.describe('when user has role "plugin" with adminPermissions checked', () => {
+      test.before(() => {
+        return utils.ensureUserAndDoLogin(authenticator, pluginUser)
+      })
+
+      test.after(() => {
+        return updateUser(pluginUserId, {
+          adminPermissions: false
+        })
+      })
+
+      test.it('should be able to update data of operator users, including role', () => {
+        return updateUser(operatorUserId, {
+          password: 'foo',
+          role: 'operator'
+        }).then(response => {
+          return test.expect(response.statusCode).to.equal(204)
+        })
+      })
+    })
+
     test.describe('when user is operator', () => {
       test.before(() => {
         return utils.ensureUserAndDoLogin(authenticator, operatorUser)
@@ -636,6 +657,17 @@ test.describe('users api', function () {
 
     test.before(() => {
       return utils.ensureUserAndDoLogin(authenticator, pluginUser)
+    })
+
+    test.it('should not be able to update self data', () => {
+      return updateUser(pluginUserId, {
+        adminPermissions: true
+      }).then(response => {
+        return Promise.all([
+          test.expect(response.body.message).to.contain('Not authorized'),
+          test.expect(response.statusCode).to.equal(403)
+        ])
+      })
     })
 
     test.describe('add user', () => {

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -568,14 +568,14 @@ test.describe('users api', function () {
         return utils.ensureUserAndDoLogin(authenticator, pluginUser).then(() => {
           return getUserMe().then(response => {
             pluginUserId = response.body._id
-                return getApiKey(pluginUserId).then(response => {
-                  console.log(response.body)
-                  pluginApiKey = response.body.apiKey
-                  console.log('----------------- pluginApiKey')
-                  console.log(pluginApiKey)
-                  authenticator.loginApiKey(response.body.name, pluginApiKey);
-                  return Promise.resolve()
-                })
+            return getApiKey(pluginUserId).then(response => {
+              console.log(response.body)
+              pluginApiKey = response.body.apiKey
+              console.log('----------------- pluginApiKey')
+              console.log(pluginApiKey)
+              authenticator.loginApiKey(response.body.name, pluginApiKey)
+              return Promise.resolve()
+            })
           })
         })
       })

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -572,11 +572,9 @@ test.describe('users api', function () {
             console.log(response.body)
             console.log('----------------- pluginUserId')
             console.log(pluginUserId)
-            return utils.doLogin(authenticator)
-              .then(() => {
-                return getApiKey({
-                  user: pluginUserId
-                }).then(response => {
+            //return utils.doLogin(authenticator)
+              //.then(() => {
+                return getApiKey(pluginUserId).then(response => {
                   console.log(response.body)
                   pluginApiKey = response.body.apiKey
                   console.log('----------------- pluginApiKey')
@@ -584,7 +582,7 @@ test.describe('users api', function () {
                   authenticator.loginApiKey(response.body.name, pluginApiKey);
                   return Promise.resolve()
                 })
-              })
+              //})
           })
         })
       })

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -548,7 +548,15 @@ test.describe('users api', function () {
 
     test.describe('when user has role "plugin" with adminPermissions checked', () => {
       test.before(() => {
-        return utils.ensureUserAndDoLogin(authenticator, pluginUser)
+        return utils.ensureUserAndDoLogin(authenticator, pluginUser).then(() => {
+          return getUserMe().then(data => {
+            console.log("----------------- userMe")
+            console.log(data)
+            console.log("----------------- pluginUserId")
+            console.log(pluginUserId)
+            return Promise.resolve()
+          })
+        })
       })
 
       test.after(() => {

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -73,6 +73,16 @@ test.describe('users api', function () {
     })
   }
 
+  const getApiKey = user => {
+    return utils.request('/auth/apikey', {
+      method: 'POST',
+      body: {
+        user
+      },
+      ...authenticator.credentials()
+    })
+  }
+
   const getAbilities = function (filters) {
     return utils.request('/abilities', {
       method: 'GET',
@@ -552,6 +562,8 @@ test.describe('users api', function () {
 
     test.describe('when user has role "plugin" with adminPermissions checked', () => {
       let pluginUserId
+      let pluginApiKey
+
       test.before(() => {
         return utils.ensureUserAndDoLogin(authenticator, pluginUser).then(() => {
           return getUserMe().then(response => {
@@ -560,7 +572,15 @@ test.describe('users api', function () {
             console.log(response.body)
             console.log('----------------- pluginUserId')
             console.log(pluginUserId)
-            return Promise.resolve()
+            return getApiKey({
+              user: response.body._id
+            }).then(response => {
+              pluginApiKey = response.apiKey
+              console.log('----------------- pluginApiKey')
+              console.log(pluginApiKey)
+              authenticator.loginApiKey(response.body.name, pluginApiKey);
+              return Promise.resolve()
+            })
           })
         })
       })

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -572,16 +572,19 @@ test.describe('users api', function () {
             console.log(response.body)
             console.log('----------------- pluginUserId')
             console.log(pluginUserId)
-            return getApiKey({
-              user: response.body._id
-            }).then(response => {
-              console.log(response)
-              pluginApiKey = response.body.apiKey
-              console.log('----------------- pluginApiKey')
-              console.log(pluginApiKey)
-              authenticator.loginApiKey(response.body.name, pluginApiKey);
-              return Promise.resolve()
-            })
+            return utils.doLogin(authenticator)
+              .then(() => {
+                return getApiKey({
+                  user: pluginUserId
+                }).then(response => {
+                  console.log(response.body)
+                  pluginApiKey = response.body.apiKey
+                  console.log('----------------- pluginApiKey')
+                  console.log(pluginApiKey)
+                  authenticator.loginApiKey(response.body.name, pluginApiKey);
+                  return Promise.resolve()
+                })
+              })
           })
         })
       })

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -569,10 +569,7 @@ test.describe('users api', function () {
           return getUserMe().then(response => {
             pluginUserId = response.body._id
             return getApiKey(pluginUserId).then(response => {
-              console.log(response.body)
               pluginApiKey = response.body.apiKey
-              console.log('----------------- pluginApiKey')
-              console.log(pluginApiKey)
               authenticator.loginApiKey(response.body.name, pluginApiKey)
               return Promise.resolve()
             })

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -575,7 +575,7 @@ test.describe('users api', function () {
             return getApiKey({
               user: response.body._id
             }).then(response => {
-              pluginApiKey = response.apiKey
+              pluginApiKey = response.body.apiKey
               console.log('----------------- pluginApiKey')
               console.log(pluginApiKey)
               authenticator.loginApiKey(response.body.name, pluginApiKey);

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -560,7 +560,7 @@ test.describe('users api', function () {
       })
     })
 
-    test.describe('when user has role "plugin" with adminPermissions checked', () => {
+    test.describe('when user has role "plugin" with adminPermissions checked and is logged using api key', () => {
       let pluginUserId
       let pluginApiKey
 
@@ -575,6 +575,7 @@ test.describe('users api', function () {
             return getApiKey({
               user: response.body._id
             }).then(response => {
+              console.log(response)
               pluginApiKey = response.body.apiKey
               console.log('----------------- pluginApiKey')
               console.log(pluginApiKey)

--- a/test/functional/specs/users-api.specs.js
+++ b/test/functional/specs/users-api.specs.js
@@ -568,12 +568,6 @@ test.describe('users api', function () {
         return utils.ensureUserAndDoLogin(authenticator, pluginUser).then(() => {
           return getUserMe().then(response => {
             pluginUserId = response.body._id
-            console.log('----------------- userMe')
-            console.log(response.body)
-            console.log('----------------- pluginUserId')
-            console.log(pluginUserId)
-            //return utils.doLogin(authenticator)
-              //.then(() => {
                 return getApiKey(pluginUserId).then(response => {
                   console.log(response.body)
                   pluginApiKey = response.body.apiKey
@@ -582,7 +576,6 @@ test.describe('users api', function () {
                   authenticator.loginApiKey(response.body.name, pluginApiKey);
                   return Promise.resolve()
                 })
-              //})
           })
         })
       })

--- a/test/unit/lib/api/users.specs.js
+++ b/test/unit/lib/api/users.specs.js
@@ -450,6 +450,47 @@ test.describe('users api', () => {
         })
       })
 
+      test.it('should resolve if target user has plugin role and only adminPermissions are being updated', () => {
+        commandsMocks.stubs.user.getById.resolves({
+          role: 'plugin'
+        })
+
+        return operations.updateUser.auth(fooUser, fooParams, {
+          adminPermissions: true
+        }).then(() => {
+          return test.expect(true).to.be.true()
+        })
+      })
+
+      test.it('should reject if target user has plugin role and any other key plus adminPermissions is being updated', () => {
+        commandsMocks.stubs.user.getById.resolves({
+          role: 'plugin'
+        })
+
+        return operations.updateUser.auth(fooUser, fooParams, {
+          adminPermissions: true,
+          name: 'foo'
+        }).then(() => {
+          return test.assert.fail()
+        }, err => {
+          return test.expect(err).to.be.an.instanceof(Error)
+        })
+      })
+
+      test.it('should reject if target user has plugin role and any other key than adminPermissions is being updated', () => {
+        commandsMocks.stubs.user.getById.resolves({
+          role: 'plugin'
+        })
+
+        return operations.updateUser.auth(fooUser, fooParams, {
+          name: 'foo'
+        }).then(() => {
+          return test.assert.fail()
+        }, err => {
+          return test.expect(err).to.be.an.instanceof(Error)
+        })
+      })
+
       test.it('should reject if user is not admin and wants to update role', () => {
         commandsMocks.stubs.user.getById.resolves({
           role: 'operator'

--- a/test/unit/lib/api/users.specs.js
+++ b/test/unit/lib/api/users.specs.js
@@ -493,7 +493,7 @@ test.describe('users api', () => {
 
       test.it('should reject if user is not admin and wants to update role', () => {
         commandsMocks.stubs.user.getById.resolves({
-          role: 'operator'
+          role: 'plugin'
         })
 
         return operations.updateUser.auth({
@@ -501,6 +501,39 @@ test.describe('users api', () => {
           role: 'operator'
         }, fooParams, {
           role: 'admin'
+        }).then(() => {
+          return test.assert.fail()
+        }, err => {
+          return test.expect(err).to.be.an.instanceof(Error)
+        })
+      })
+
+      test.it('should reject if user is admin and wants to update adminPermissions of a non plugin user', () => {
+        commandsMocks.stubs.user.getById.resolves({
+          role: 'operator'
+        })
+
+        return operations.updateUser.auth({
+          fooUser
+        }, fooParams, {
+          adminPermissions: true
+        }).then(() => {
+          return test.assert.fail()
+        }, err => {
+          return test.expect(err).to.be.an.instanceof(Error)
+        })
+      })
+
+      test.it('should reject if user is admin and wants to update adminPermissions', () => {
+        commandsMocks.stubs.user.getById.resolves({
+          role: 'operator'
+        })
+
+        return operations.updateUser.auth({
+          ...fooUser,
+          role: 'plugin'
+        }, fooParams, {
+          adminPermissions: true
         }).then(() => {
           return test.assert.fail()
         }, err => {

--- a/test/unit/lib/commands/securityToken.specs.js
+++ b/test/unit/lib/commands/securityToken.specs.js
@@ -41,6 +41,10 @@ test.describe('securityToken commands', () => {
       const fooUserData = {
         _id: fooUserId
       }
+      const fooCreatorId = 'foo-creator-id'
+      const fooCreatorData = {
+        _id: fooCreatorId
+      }
       test.it('should create and save a SecurityToken model with the received user data', () => {
         return commands.add(fooUserData, 'jwt')
           .then(() => {
@@ -49,7 +53,24 @@ test.describe('securityToken commands', () => {
               test.expect(modelsMocks.stubs.SecurityToken).to.have.been.calledWith({
                 _user: fooUserId,
                 token: 'foo-token',
-                type: 'jwt'
+                type: 'jwt',
+                createdBy: undefined
+              }),
+              test.expect(modelsMocks.stubs.securityToken.save).to.have.been.called()
+            ])
+          })
+      })
+
+      test.it('should add the user creator id to the securityToken', () => {
+        return commands.add(fooUserData, 'apiKey', fooCreatorData)
+          .then(() => {
+            return Promise.all([
+              test.expect(randTokenStub).to.have.been.called(),
+              test.expect(modelsMocks.stubs.SecurityToken).to.have.been.calledWith({
+                _user: fooUserId,
+                token: 'foo-token',
+                type: 'apiKey',
+                createdBy: fooCreatorId
               }),
               test.expect(modelsMocks.stubs.securityToken.save).to.have.been.called()
             ])

--- a/test/unit/lib/security/utils.specs.js
+++ b/test/unit/lib/security/utils.specs.js
@@ -58,6 +58,30 @@ test.describe('security utils', () => {
           ])
         })
     })
+
+    test.it('should override role to admin if user has adminPermissions property set to true', () => {
+      const fooToken = 'fooToken'
+      commandsMocks.stubs.securityToken.getUser.resolves({
+        _id: 'fooId',
+        name: 'fooName',
+        email: 'fooEmail',
+        role: 'fooRole',
+        password: 'fooPassword',
+        adminPermissions: true
+      })
+      return getUserBySecurityToken(fooToken)
+        .then(result => {
+          return Promise.all([
+            test.expect(commandsMocks.stubs.securityToken.getUser).to.have.been.calledWith(fooToken),
+            test.expect(result).to.deep.equal({
+              _id: 'fooId',
+              name: 'fooName',
+              email: 'fooEmail',
+              role: 'admin'
+            })
+          ])
+        })
+    })
   })
 
   test.describe('AdminOrOwner instance', () => {


### PR DESCRIPTION
- Add user adminPermissions property, intended for grant admin permissions to plugin users when login using apiKey
- Avoid any other user than admin updating adminPermissions property